### PR TITLE
chore: fix TypeScript errors in tests

### DIFF
--- a/frontend/src/app/api/assessment/scenarios/[id]/__tests__/route.test.ts
+++ b/frontend/src/app/api/assessment/scenarios/[id]/__tests__/route.test.ts
@@ -66,18 +66,18 @@ describe('Assessment Scenario API Route', () => {
         } as ITaskTemplate
       ];
 
-      const mockScenario: IScenario = {
-        id: 'test-scenario-id',
-        mode: 'assessment',
-        status: 'active',
-        sourceType: 'yaml',
-        title: { en: 'Test Assessment', zh: '測試評估' },
-        description: { en: 'Test Description', zh: '測試說明' },
-        objectives: {},
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        taskTemplates: mockTaskTemplates
-      };
+        const mockScenario: IScenario = {
+          id: 'test-scenario-id',
+          mode: 'assessment',
+          status: 'active',
+          sourceType: 'yaml',
+          title: { en: 'Test Assessment', zh: '測試評估' },
+          description: { en: 'Test Description', zh: '測試說明' },
+          objectives: [],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          taskTemplates: mockTaskTemplates
+        } as any;
 
       mockScenarioRepo.findById.mockResolvedValue(mockScenario);
 
@@ -103,17 +103,17 @@ describe('Assessment Scenario API Route', () => {
     });
 
     it('should use language-specific title and description', async () => {
-      const mockScenario: IScenario = {
-        id: 'test-scenario-id',
-        mode: 'assessment',
-        status: 'active',
-        sourceType: 'yaml',
-        title: { en: 'English Title', zh: '中文標題' },
-        description: { en: 'English Description', zh: '中文說明' },
-        objectives: {},
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
-      };
+        const mockScenario: IScenario = {
+          id: 'test-scenario-id',
+          mode: 'assessment',
+          status: 'active',
+          sourceType: 'yaml',
+          title: { en: 'English Title', zh: '中文標題' },
+          description: { en: 'English Description', zh: '中文說明' },
+          objectives: [],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
+        } as any;
 
       mockScenarioRepo.findById.mockResolvedValue(mockScenario);
 
@@ -129,17 +129,17 @@ describe('Assessment Scenario API Route', () => {
     });
 
     it('should handle string title and description', async () => {
-      const mockScenario: IScenario = {
-        id: 'test-scenario-id',
-        mode: 'assessment',
-        status: 'active',
-        sourceType: 'yaml',
-        title: 'String Title' as any, // Simulating legacy data
-        description: 'String Description' as any,
-        objectives: {},
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
-      };
+        const mockScenario: IScenario = {
+          id: 'test-scenario-id',
+          mode: 'assessment',
+          status: 'active',
+          sourceType: 'yaml',
+          title: 'String Title' as any, // Simulating legacy data
+          description: 'String Description' as any,
+          objectives: [],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
+        } as any;
 
       mockScenarioRepo.findById.mockResolvedValue(mockScenario);
 
@@ -168,18 +168,18 @@ describe('Assessment Scenario API Route', () => {
     });
 
     it('should use default config when no taskTemplates', async () => {
-      const mockScenario: IScenario = {
+      const mockScenario = {
         id: 'test-scenario-id',
         mode: 'assessment',
         status: 'active',
         sourceType: 'yaml',
         title: { en: 'Test Assessment' },
         description: { en: 'Test Description' },
-        objectives: {},
+          objectives: [],
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString()
         // No taskTemplates
-      };
+      } as any;
 
       mockScenarioRepo.findById.mockResolvedValue(mockScenario);
 
@@ -222,18 +222,18 @@ describe('Assessment Scenario API Route', () => {
         } as ITaskTemplate
       ];
 
-      const mockScenario: IScenario = {
-        id: 'test-scenario-id',
-        mode: 'assessment',
-        status: 'active',
-        sourceType: 'yaml',
-        title: { en: 'Test Assessment' },
-        description: { en: 'Test Description' },
-        objectives: {},
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        taskTemplates: mockTaskTemplates
-      };
+        const mockScenario: IScenario = {
+          id: 'test-scenario-id',
+          mode: 'assessment',
+          status: 'active',
+          sourceType: 'yaml',
+          title: { en: 'Test Assessment' },
+          description: { en: 'Test Description' },
+          objectives: [],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          taskTemplates: mockTaskTemplates
+        } as any;
 
       mockScenarioRepo.findById.mockResolvedValue(mockScenario);
 
@@ -253,17 +253,17 @@ describe('Assessment Scenario API Route', () => {
     });
 
     it('should fallback to English for missing language', async () => {
-      const mockScenario: IScenario = {
-        id: 'test-scenario-id',
-        mode: 'assessment',
-        status: 'active',
-        sourceType: 'yaml',
-        title: { en: 'English Title', zh: '中文標題' },
-        description: { en: 'English Description', zh: '中文說明' },
-        objectives: {},
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
-      };
+        const mockScenario: IScenario = {
+          id: 'test-scenario-id',
+          mode: 'assessment',
+          status: 'active',
+          sourceType: 'yaml',
+          title: { en: 'English Title', zh: '中文標題' },
+          description: { en: 'English Description', zh: '中文說明' },
+          objectives: [],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
+        } as any;
 
       mockScenarioRepo.findById.mockResolvedValue(mockScenario);
 
@@ -279,17 +279,17 @@ describe('Assessment Scenario API Route', () => {
     });
 
     it('should handle missing title and description', async () => {
-      const mockScenario: IScenario = {
-        id: 'test-scenario-id',
-        mode: 'assessment',
-        status: 'active',
-        sourceType: 'yaml',
-        title: undefined as any, // Missing title
-        description: undefined as any, // Missing description
-        objectives: {},
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
-      };
+        const mockScenario: IScenario = {
+          id: 'test-scenario-id',
+          mode: 'assessment',
+          status: 'active',
+          sourceType: 'yaml',
+          title: undefined as any, // Missing title
+          description: undefined as any, // Missing description
+          objectives: [],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
+        } as any;
 
       mockScenarioRepo.findById.mockResolvedValue(mockScenario);
 
@@ -322,17 +322,17 @@ describe('Assessment Scenario API Route', () => {
     });
 
     it('should default to English when no lang parameter', async () => {
-      const mockScenario: IScenario = {
-        id: 'test-scenario-id',
-        mode: 'assessment',
-        status: 'active',
-        sourceType: 'yaml',
-        title: { en: 'English Title', zh: '中文標題' },
-        description: { en: 'English Description', zh: '中文說明' },
-        objectives: {},
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString()
-      };
+        const mockScenario: IScenario = {
+          id: 'test-scenario-id',
+          mode: 'assessment',
+          status: 'active',
+          sourceType: 'yaml',
+          title: { en: 'English Title', zh: '中文標題' },
+          description: { en: 'English Description', zh: '中文說明' },
+          objectives: [],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
+        } as any;
 
       mockScenarioRepo.findById.mockResolvedValue(mockScenario);
 

--- a/frontend/src/lib/repositories/gcs/__tests__/media-repository.test.ts
+++ b/frontend/src/lib/repositories/gcs/__tests__/media-repository.test.ts
@@ -65,7 +65,7 @@ describe('GCSMediaRepository', () => {
       };
 
       mockFile.createWriteStream.mockReturnValue(mockStream as any);
-      mockFile.makePublic.mockResolvedValue([{}] as any);
+      (mockFile.makePublic as any).mockResolvedValue([{}]);
 
       // Simulate successful upload
       mockStream.on.mockImplementation((event, callback) => {
@@ -130,8 +130,8 @@ describe('GCSMediaRepository', () => {
 
   describe('getFileUrl', () => {
     it('should return public URL for public files', async () => {
-      mockFile.exists.mockResolvedValue([true]);
-      mockFile.getMetadata.mockResolvedValue([{
+        (mockFile.exists as any).mockResolvedValue([true]);
+        (mockFile.getMetadata as any).mockResolvedValue([{
         acl: [{ entity: 'allUsers', role: 'READER' }]
       }]);
 
@@ -141,11 +141,11 @@ describe('GCSMediaRepository', () => {
     });
 
     it('should return signed URL for private files', async () => {
-      mockFile.exists.mockResolvedValue([true]);
-      mockFile.getMetadata.mockResolvedValue([{
-        acl: []
-      }]);
-      mockFile.getSignedUrl.mockResolvedValue(['https://signed-url']);
+      (mockFile.exists as any).mockResolvedValue([true]);
+      (mockFile.getMetadata as any).mockResolvedValue([
+          { acl: [] }
+        ]);
+      (mockFile.getSignedUrl as any).mockResolvedValue(['https://signed-url']);
 
       const url = await repository.getFileUrl('images/test.jpg');
 
@@ -158,7 +158,7 @@ describe('GCSMediaRepository', () => {
     });
 
     it('should throw error for non-existent files', async () => {
-      mockFile.exists.mockResolvedValue([false]);
+      (mockFile.exists as any).mockResolvedValue([false]);
 
       await expect(repository.getFileUrl('images/test.jpg'))
         .rejects.toThrow('File not found: images/test.jpg');
@@ -169,7 +169,7 @@ describe('GCSMediaRepository', () => {
 
   describe('deleteFile', () => {
     it('should delete file successfully', async () => {
-      mockFile.delete.mockResolvedValue([{}] as any);
+      (mockFile.delete as any).mockResolvedValue([{}] as any);
 
       const result = await repository.deleteFile('images/test.jpg');
 
@@ -178,7 +178,7 @@ describe('GCSMediaRepository', () => {
     });
 
     it('should return false on deletion error', async () => {
-      mockFile.delete.mockRejectedValue(new Error('Delete failed'));
+      (mockFile.delete as any).mockRejectedValue(new Error('Delete failed'));
 
       const result = await repository.deleteFile('images/test.jpg');
 
@@ -208,7 +208,7 @@ describe('GCSMediaRepository', () => {
         }
       ];
 
-      mockBucket.getFiles.mockResolvedValue([mockFiles as any, null, null]);
+        (mockBucket.getFiles as any).mockResolvedValue([mockFiles as any, null, null]);
       
       // Mock getFileUrl for each file
       const getFileUrlSpy = jest.spyOn(repository, 'getFileUrl');
@@ -216,7 +216,7 @@ describe('GCSMediaRepository', () => {
 
       const result = await repository.listFiles('images/');
 
-      expect(mockBucket.getFiles).toHaveBeenCalledWith({
+      expect((mockBucket.getFiles as any)).toHaveBeenCalledWith({
         prefix: 'images/',
         delimiter: '/'
       });
@@ -239,7 +239,7 @@ describe('GCSMediaRepository', () => {
     });
 
     it('should handle listing errors', async () => {
-      mockBucket.getFiles.mockRejectedValue(new Error('List failed'));
+      (mockBucket.getFiles as any).mockRejectedValue(new Error('List failed'));
 
       await expect(repository.listFiles('images/'))
         .rejects.toThrow('List failed');
@@ -255,7 +255,7 @@ describe('GCSMediaRepository', () => {
         }
       ];
 
-      mockBucket.getFiles.mockResolvedValue([mockFiles as any, null, null]);
+      (mockBucket.getFiles as any).mockResolvedValue([mockFiles as any, null, null]);
       
       const getFileUrlSpy = jest.spyOn(repository, 'getFileUrl');
       getFileUrlSpy.mockResolvedValue('https://storage.googleapis.com/test-bucket/images/file1.jpg');
@@ -307,7 +307,7 @@ describe('GCSMediaRepository', () => {
 
   describe('getUploadUrl', () => {
     it('should generate pre-signed upload URL', async () => {
-      mockFile.getSignedUrl.mockResolvedValue(['https://signed-upload-url']);
+      (mockFile.getSignedUrl as any).mockResolvedValue(['https://signed-upload-url']);
 
       const result = await repository.getUploadUrl('images/test.jpg', 'image/jpeg', 60);
 
@@ -324,12 +324,12 @@ describe('GCSMediaRepository', () => {
     });
 
     it('should use default expiry time', async () => {
-      mockFile.getSignedUrl.mockResolvedValue(['https://signed-upload-url']);
+      (mockFile.getSignedUrl as any).mockResolvedValue(['https://signed-upload-url']);
 
       await repository.getUploadUrl('images/test.jpg', 'image/jpeg');
 
-      const call = mockFile.getSignedUrl.mock.calls[0][0];
-      const expiryTime = call.expires - Date.now();
+      const call = (mockFile.getSignedUrl.mock.calls[0][0] as any);
+      const expiryTime = (call.expires as number) - Date.now();
       
       // Should be approximately 30 minutes
       expect(expiryTime).toBeGreaterThan(29 * 60 * 1000);
@@ -338,8 +338,8 @@ describe('GCSMediaRepository', () => {
   });
 
   describe('copyFile', () => {
-    it('should copy file successfully', async () => {
-      mockFile.copy.mockResolvedValue([{} as any, {}]);
+      it('should copy file successfully', async () => {
+        (mockFile.copy as any).mockResolvedValue([{} as any, {}]);
       const getFileUrlSpy = jest.spyOn(repository, 'getFileUrl');
       getFileUrlSpy.mockResolvedValue('https://storage.googleapis.com/test-bucket/images/copy.jpg');
 
@@ -352,7 +352,7 @@ describe('GCSMediaRepository', () => {
     });
 
     it('should handle copy errors', async () => {
-      mockFile.copy.mockRejectedValue(new Error('Copy failed'));
+      (mockFile.copy as any).mockRejectedValue(new Error('Copy failed'));
 
       await expect(repository.copyFile('images/original.jpg', 'images/copy.jpg'))
         .rejects.toThrow('Copy failed');
@@ -379,7 +379,7 @@ describe('GCSMediaRepository', () => {
 
   describe('exists', () => {
     it('should return true for existing files', async () => {
-      mockFile.exists.mockResolvedValue([true]);
+      (mockFile.exists as any).mockResolvedValue([true]);
 
       const result = await repository.exists('images/test.jpg');
 
@@ -387,7 +387,7 @@ describe('GCSMediaRepository', () => {
     });
 
     it('should return false for non-existent files', async () => {
-      mockFile.exists.mockResolvedValue([false]);
+      (mockFile.exists as any).mockResolvedValue([false]);
 
       const result = await repository.exists('images/test.jpg');
 
@@ -395,7 +395,7 @@ describe('GCSMediaRepository', () => {
     });
 
     it('should return false on error', async () => {
-      mockFile.exists.mockRejectedValue(new Error('Check failed'));
+      (mockFile.exists as any).mockRejectedValue(new Error('Check failed'));
 
       const result = await repository.exists('images/test.jpg');
 
@@ -411,7 +411,7 @@ describe('GCSMediaRepository', () => {
         contentType: 'image/jpeg',
         updated: '2024-01-20T10:00:00Z'
       };
-      mockFile.getMetadata.mockResolvedValue([mockMetadata]);
+      (mockFile.getMetadata as any).mockResolvedValue([mockMetadata]);
 
       const result = await repository.getMetadata('images/test.jpg');
 
@@ -419,7 +419,7 @@ describe('GCSMediaRepository', () => {
     });
 
     it('should handle metadata errors', async () => {
-      mockFile.getMetadata.mockRejectedValue(new Error('Metadata failed'));
+      (mockFile.getMetadata as any).mockRejectedValue(new Error('Metadata failed'));
 
       await expect(repository.getMetadata('images/test.jpg'))
         .rejects.toThrow('Metadata failed');
@@ -430,7 +430,7 @@ describe('GCSMediaRepository', () => {
 
   describe('setMetadata', () => {
     it('should set custom metadata successfully', async () => {
-      mockFile.setMetadata.mockResolvedValue([{}] as any);
+      (mockFile.setMetadata as any).mockResolvedValue([{}] as any);
 
       await repository.setMetadata('images/test.jpg', { author: 'John Doe' });
 
@@ -440,7 +440,7 @@ describe('GCSMediaRepository', () => {
     });
 
     it('should handle set metadata errors', async () => {
-      mockFile.setMetadata.mockRejectedValue(new Error('Set metadata failed'));
+      (mockFile.setMetadata as any).mockRejectedValue(new Error('Set metadata failed'));
 
       await expect(repository.setMetadata('images/test.jpg', { author: 'John Doe' }))
         .rejects.toThrow('Set metadata failed');
@@ -452,7 +452,7 @@ describe('GCSMediaRepository', () => {
   describe('downloadFile', () => {
     it('should download file content successfully', async () => {
       const mockContent = Buffer.from('file content');
-      mockFile.download.mockResolvedValue([mockContent]);
+      (mockFile.download as any).mockResolvedValue([mockContent]);
 
       const result = await repository.downloadFile('images/test.jpg');
 
@@ -460,7 +460,7 @@ describe('GCSMediaRepository', () => {
     });
 
     it('should handle download errors', async () => {
-      mockFile.download.mockRejectedValue(new Error('Download failed'));
+      (mockFile.download as any).mockRejectedValue(new Error('Download failed'));
 
       await expect(repository.downloadFile('images/test.jpg'))
         .rejects.toThrow('Download failed');
@@ -472,8 +472,8 @@ describe('GCSMediaRepository', () => {
   describe('isPublic (private method)', () => {
     it('should identify public files correctly', async () => {
       // Test through getFileUrl which uses isPublic
-      mockFile.exists.mockResolvedValue([true]);
-      mockFile.getMetadata.mockResolvedValue([{
+        (mockFile.exists as any).mockResolvedValue([true]);
+        (mockFile.getMetadata as any).mockResolvedValue([{
         acl: [
           { entity: 'user-123', role: 'OWNER' },
           { entity: 'allUsers', role: 'READER' }
@@ -488,9 +488,9 @@ describe('GCSMediaRepository', () => {
     });
 
     it('should handle missing ACL', async () => {
-      mockFile.exists.mockResolvedValue([true]);
-      mockFile.getMetadata.mockResolvedValue([{}]); // No ACL
-      mockFile.getSignedUrl.mockResolvedValue(['https://signed-url']);
+        (mockFile.exists as any).mockResolvedValue([true]);
+        (mockFile.getMetadata as any).mockResolvedValue([{}]); // No ACL
+        (mockFile.getSignedUrl as any).mockResolvedValue(['https://signed-url']);
 
       const url = await repository.getFileUrl('images/test.jpg');
 

--- a/frontend/src/lib/repositories/postgresql/__tests__/task-repository.test.ts
+++ b/frontend/src/lib/repositories/postgresql/__tests__/task-repository.test.ts
@@ -27,8 +27,8 @@ describe('PostgreSQLTaskRepository', () => {
     mode: 'pbl',
     task_index: 0,
     scenario_task_index: 1,
-    title: { en: 'Test Task', zh: '測試任務' },
-    description: { en: 'Test Description' },
+    title: { en: 'Test Task', zh: '測試任務' } as any,
+    description: { en: 'Test Description' } as any,
     type: 'question' as TaskType,
     status: 'active' as TaskStatus,
     content: { instructions: 'Do this task' },
@@ -214,6 +214,7 @@ describe('PostgreSQLTaskRepository', () => {
         discoveryData: {},
         assessmentData: {},
         metadata: {},
+        status: 'active' as TaskStatus,
         createdAt: '',
         updatedAt: ''
       };

--- a/frontend/src/lib/services/__tests__/discovery-learning-service.test.ts
+++ b/frontend/src/lib/services/__tests__/discovery-learning-service.test.ts
@@ -63,9 +63,10 @@ describe('DiscoveryLearningService', () => {
     id: 'scenario-123',
     mode: 'discovery',
     status: 'active',
-    sourceType: 'yaml',
-    sourcePath: 'discovery/content_creator',
-    title: { en: 'Content Creator Path' },
+      sourceType: 'yaml',
+      sourcePath: 'discovery/content_creator',
+      sourceMetadata: {},
+      title: { en: 'Content Creator Path' },
     description: { en: 'Explore content creation' },
     objectives: ['Learn skills', 'Build portfolio'],
     taskTemplates: [],
@@ -191,7 +192,7 @@ describe('DiscoveryLearningService', () => {
     it('should start a discovery learning journey', async () => {
       mockScenarioRepo.findById.mockResolvedValue(mockScenario);
       mockProgramRepo.create.mockResolvedValue(mockProgram);
-      mockTaskRepo.create.mockImplementation((task) => 
+      mockTaskRepo.create.mockImplementation((task: any) =>
         Promise.resolve({ ...task, id: `task-${Date.now()}` })
       );
 
@@ -227,7 +228,7 @@ describe('DiscoveryLearningService', () => {
     it('should use specified language', async () => {
       mockScenarioRepo.findById.mockResolvedValue(mockScenario);
       mockProgramRepo.create.mockResolvedValue(mockProgram);
-      mockTaskRepo.create.mockImplementation((task) => 
+      mockTaskRepo.create.mockImplementation((task: any) =>
         Promise.resolve({ ...task, id: `task-${Date.now()}` })
       );
 
@@ -308,7 +309,7 @@ describe('DiscoveryLearningService', () => {
     it('should submit response and complete task', async () => {
       mockTaskRepo.findById.mockResolvedValue(mockTask);
       mockProgramRepo.findById.mockResolvedValue(mockProgram);
-      mockTaskRepo.create.mockImplementation((task) => 
+      mockTaskRepo.create.mockImplementation((task: any) =>
         Promise.resolve({ ...task, id: `task-new-${Date.now()}` })
       );
 
@@ -573,9 +574,9 @@ describe('DiscoveryLearningService', () => {
       mockTaskRepo.findById.mockResolvedValue(advancedTask);
       mockProgramRepo.findById.mockResolvedValue(mockProgram);
 
-      const result = await service.submitResponse('program-123', 'task-123', { completed: true });
+        const result = await service.submitResponse('program-123', 'task-123', { completed: true });
 
-      expect(result.metadata.newAchievements).toContain('Advanced Challenge Master');
+        expect(result.metadata!.newAchievements).toContain('Advanced Challenge Master');
     });
 
     it('should handle tasks with skills to unlock', async () => {
@@ -589,9 +590,9 @@ describe('DiscoveryLearningService', () => {
       mockTaskRepo.findById.mockResolvedValue(taskWithSkills);
       mockProgramRepo.findById.mockResolvedValue(mockProgram);
 
-      const result = await service.submitResponse('program-123', 'task-123', { completed: true });
+        const result = await service.submitResponse('program-123', 'task-123', { completed: true });
 
-      expect(result.metadata.skillsUnlocked).toEqual(['writing', 'design']);
+        expect(result.metadata!.skillsUnlocked).toEqual(['writing', 'design']);
     });
 
     it('should handle empty skill progress normalization', async () => {
@@ -726,7 +727,7 @@ describe('DiscoveryLearningService', () => {
       const advancedProgram = {
         ...mockProgram,
         discoveryData: {
-          ...mockProgram.discoveryData as DiscoveryProgress,
+          ...(mockProgram.discoveryData as unknown as DiscoveryProgress),
           level: 6,
           completedChallenges: ['writing', 'design']
         }

--- a/frontend/src/lib/services/__tests__/pbl-learning-service.test.ts
+++ b/frontend/src/lib/services/__tests__/pbl-learning-service.test.ts
@@ -50,13 +50,14 @@ describe('PBLLearningService', () => {
     }
   ];
 
-  const mockScenario: IScenario = {
-    id: 'scenario-123',
-    mode: 'pbl',
-    status: 'active',
-    sourceType: 'yaml',
-    sourcePath: 'pbl/ai_ethics',
-    title: { en: 'AI Ethics Challenge' },
+    const mockScenario: IScenario = {
+      id: 'scenario-123',
+      mode: 'pbl',
+      status: 'active',
+      sourceType: 'yaml',
+      sourcePath: 'pbl/ai_ethics',
+      sourceMetadata: {},
+      title: { en: 'AI Ethics Challenge' },
     description: { en: 'Explore AI ethics' },
     objectives: ['Understand AI ethics', 'Create ethical guidelines'],
     taskTemplates: mockTaskTemplates,
@@ -185,7 +186,7 @@ describe('PBLLearningService', () => {
     it('should start a PBL learning journey', async () => {
       mockScenarioRepo.findById.mockResolvedValue(mockScenario);
       mockProgramRepo.create.mockResolvedValue(mockProgram);
-      mockTaskRepo.create.mockImplementation((task) => 
+      mockTaskRepo.create.mockImplementation((task: any) =>
         Promise.resolve({ ...task, id: `task-${Date.now()}` })
       );
 
@@ -222,7 +223,7 @@ describe('PBLLearningService', () => {
     it('should use specified language', async () => {
       mockScenarioRepo.findById.mockResolvedValue(mockScenario);
       mockProgramRepo.create.mockResolvedValue(mockProgram);
-      mockTaskRepo.create.mockImplementation((task) => 
+      mockTaskRepo.create.mockImplementation((task: any) =>
         Promise.resolve({ ...task, id: `task-${Date.now()}` })
       );
 
@@ -264,7 +265,7 @@ describe('PBLLearningService', () => {
     it('should set correct phases for tasks', async () => {
       mockScenarioRepo.findById.mockResolvedValue(mockScenario);
       mockProgramRepo.create.mockResolvedValue(mockProgram);
-      mockTaskRepo.create.mockImplementation((task) => 
+      mockTaskRepo.create.mockImplementation((task: any) =>
         Promise.resolve({ ...task, id: `task-${Date.now()}` })
       );
 
@@ -376,7 +377,7 @@ describe('PBLLearningService', () => {
 
       const result = await service.getProgress('program-123');
 
-      expect(result.metadata.currentTaskId).toBeUndefined();
+      expect(result.metadata!.currentTaskId).toBeUndefined();
     });
   });
 
@@ -436,7 +437,7 @@ describe('PBLLearningService', () => {
 
       const result = await service.submitResponse('program-123', 'task-123', {});
 
-      expect(result.metadata.aiResponse).toMatchObject({
+      expect(result.metadata!.aiResponse).toMatchObject({
         message: expect.stringContaining('Excellent research'),
         feedback: expect.stringContaining('exploration is thorough')
       });
@@ -503,7 +504,7 @@ describe('PBLLearningService', () => {
 
       const result = await service.submitResponse('program-123', 'task-123', {});
 
-      expect(result.metadata.aiResponse).toMatchObject({
+      expect(result.metadata!.aiResponse).toMatchObject({
         message: expect.stringContaining('Your solution is innovative'),
         feedback: expect.stringContaining('Creative problem-solving')
       });
@@ -516,7 +517,7 @@ describe('PBLLearningService', () => {
       const result = await service.submitResponse('program-123', 'task-123', {});
 
       // Should default to understanding phase
-      expect(result.metadata.aiResponse).toMatchObject({
+      expect(result.metadata!.aiResponse).toMatchObject({
         message: expect.stringContaining("That's a good observation"),
         feedback: expect.stringContaining("showing good understanding")
       });
@@ -795,7 +796,7 @@ describe('PBLLearningService', () => {
 
       const result = await service.getProgress('program-123');
 
-      expect(result.metadata.currentPhase).toBeUndefined();
+      expect(result.metadata!.currentPhase).toBeUndefined();
     });
 
     it('should handle task without pblData in AI response generation', async () => {
@@ -808,7 +809,7 @@ describe('PBLLearningService', () => {
       const result = await service.submitResponse('program-123', 'task-123', {});
 
       // Should default to understanding phase
-      expect(result.metadata.aiResponse).toMatchObject({
+      expect(result.metadata!.aiResponse).toMatchObject({
         message: expect.stringContaining("That's a good observation")
       });
     });

--- a/frontend/src/lib/services/__tests__/scenario-initialization-service.test.ts
+++ b/frontend/src/lib/services/__tests__/scenario-initialization-service.test.ts
@@ -202,7 +202,7 @@ describe('ScenarioInitializationService', () => {
         programs: [{ tasks: [{}, {}, {}] }],
         ksa_mappings: [],
         ai_modules: {}
-      });
+      } as any);
 
       mockDiscoveryLoader.loadPath.mockResolvedValue({
         metadata: {
@@ -215,7 +215,7 @@ describe('ScenarioInitializationService', () => {
         difficulty_range: ['beginner', 'intermediate'],
         world_setting: {},
         skill_tree: {}
-      });
+      } as any);
 
       mockAssessmentLoader.loadAssessment.mockResolvedValue({
         metadata: {
@@ -225,7 +225,7 @@ describe('ScenarioInitializationService', () => {
           available_languages: ['en']
         },
         domains: []
-      });
+      } as any);
 
       // Mock getAvailableLanguages for assessments
       mockAssessmentLoader.getAvailableLanguages = jest.fn().mockResolvedValue(['en']);
@@ -237,7 +237,7 @@ describe('ScenarioInitializationService', () => {
 
       // Mock repo methods
       mockScenarioRepo.findByMode.mockResolvedValue([]);
-      mockScenarioRepo.create.mockImplementation((data) => 
+      mockScenarioRepo.create.mockImplementation((data: any) =>
         Promise.resolve({ ...data, id: `${data.mode}-scenario-123` })
       );
 
@@ -255,23 +255,23 @@ describe('ScenarioInitializationService', () => {
 
   describe('initializePBLScenarios', () => {
     it('should initialize PBL scenarios', async () => {
-      mockPBLLoader.scanScenarios.mockResolvedValue(['ai_ethics', 'data_privacy']);
-      mockPBLLoader.loadScenario.mockResolvedValue({
-        scenario_info: {
-          title: 'AI Ethics Challenge',
-          description: 'Explore AI ethics',
-          learning_objectives: ['Understand AI ethics'],
-          difficulty: 'intermediate',
-          estimated_duration: '120 minutes',
-          target_domains: ['Engaging_with_AI']
-        },
-        programs: [{ tasks: [{}, {}, {}] }],
-        ksa_mappings: [],
-        ai_modules: {}
-      });
+        mockPBLLoader.scanScenarios.mockResolvedValue(['ai_ethics', 'data_privacy']);
+        mockPBLLoader.loadScenario.mockResolvedValue({
+          scenario_info: {
+            title: 'AI Ethics Challenge',
+            description: 'Explore AI ethics',
+            learning_objectives: ['Understand AI ethics'],
+            difficulty: 'intermediate',
+            estimated_duration: '120 minutes',
+            target_domains: ['Engaging_with_AI']
+          },
+          programs: [{ tasks: [{}, {}, {}] }],
+          ksa_mappings: [],
+          ai_modules: {}
+        } as any);
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
-      mockScenarioRepo.create.mockImplementation((data) => 
+      mockScenarioRepo.create.mockImplementation((data: any) =>
         Promise.resolve({ ...data, id: 'pbl-123' })
       );
 
@@ -305,7 +305,7 @@ describe('ScenarioInitializationService', () => {
           estimated_duration: '180 minutes'
         },
         programs: [{ tasks: [{}, {}, {}, {}] }]
-      });
+      } as any);
 
       mockScenarioRepo.findByMode.mockResolvedValue([mockPBLScenario]);
       mockScenarioRepo.update.mockResolvedValue({ ...mockPBLScenario, title: { en: 'Updated AI Ethics Challenge' } });
@@ -324,10 +324,10 @@ describe('ScenarioInitializationService', () => {
     });
 
     it('should handle dry run mode', async () => {
-      mockPBLLoader.scanScenarios.mockResolvedValue(['ai_ethics']);
-      mockPBLLoader.loadScenario.mockResolvedValue({
-        scenario_info: { title: 'AI Ethics Challenge' }
-      });
+        mockPBLLoader.scanScenarios.mockResolvedValue(['ai_ethics']);
+        mockPBLLoader.loadScenario.mockResolvedValue({
+          scenario_info: { title: 'AI Ethics Challenge' }
+        } as any);
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
 
@@ -339,9 +339,9 @@ describe('ScenarioInitializationService', () => {
 
     it('should handle errors during processing', async () => {
       mockPBLLoader.scanScenarios.mockResolvedValue(['ai_ethics', 'broken_scenario']);
-      mockPBLLoader.loadScenario
-        .mockResolvedValueOnce({ scenario_info: { title: 'AI Ethics' } })
-        .mockRejectedValueOnce(new Error('Failed to load'));
+        mockPBLLoader.loadScenario
+          .mockResolvedValueOnce({ scenario_info: { title: 'AI Ethics' } } as any)
+          .mockRejectedValueOnce(new Error('Failed to load'));
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
       mockScenarioRepo.create.mockResolvedValue(mockPBLScenario);
@@ -379,10 +379,10 @@ describe('ScenarioInitializationService', () => {
         difficulty_range: ['beginner', 'intermediate'],
         world_setting: {},
         skill_tree: {}
-      });
+      } as any);
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
-      mockScenarioRepo.create.mockImplementation((data) => 
+      mockScenarioRepo.create.mockImplementation((data: any) =>
         Promise.resolve({ ...data, id: 'discovery-123' })
       );
 
@@ -414,10 +414,10 @@ describe('ScenarioInitializationService', () => {
       mockDiscoveryLoader.loadPath.mockResolvedValue({
         category: 'test'
         // No metadata
-      });
+      } as any);
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
-      mockScenarioRepo.create.mockImplementation((data) => 
+      mockScenarioRepo.create.mockImplementation((data: any) =>
         Promise.resolve({ ...data, id: 'discovery-min' })
       );
 
@@ -456,7 +456,7 @@ describe('ScenarioInitializationService', () => {
             questions: [{}, {}, {}, {}]
           }
         ]
-      });
+      } as any);
 
       // Mock getAvailableLanguages for assessments
       mockAssessmentLoader.getAvailableLanguages = jest.fn().mockResolvedValue(['en']);
@@ -467,7 +467,7 @@ describe('ScenarioInitializationService', () => {
       });
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
-      mockScenarioRepo.create.mockImplementation((data) => 
+        mockScenarioRepo.create.mockImplementation((data: any) =>
         Promise.resolve({ ...data, id: 'assessment-123' })
       );
 
@@ -480,20 +480,20 @@ describe('ScenarioInitializationService', () => {
 
     it('should calculate question count from domains', async () => {
       mockAssessmentLoader.scanAssessments.mockResolvedValue(['ai_literacy']);
-      mockAssessmentLoader.loadAssessment.mockResolvedValue({
-        metadata: { name: 'AI Literacy' },
-        domains: [
-          { questions: [{}, {}, {}] },
-          { questions: [{}, {}] }
-        ]
-      });
+        mockAssessmentLoader.loadAssessment.mockResolvedValue({
+          metadata: { name: 'AI Literacy' },
+          domains: [
+            { questions: [{}, {}, {}] },
+            { questions: [{}, {}] }
+          ]
+        } as any);
 
       // Mock getAvailableLanguages for assessments
       mockAssessmentLoader.getAvailableLanguages = jest.fn().mockResolvedValue(['en']);
       mockAssessmentLoader.getTranslatedField = jest.fn().mockReturnValue('');
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
-      mockScenarioRepo.create.mockImplementation((data) => {
+        mockScenarioRepo.create.mockImplementation((data: any) => {
         expect(data.taskCount).toBe(5); // 3 + 2 questions
         return Promise.resolve({ ...data, id: 'assessment-123' });
       });
@@ -503,16 +503,16 @@ describe('ScenarioInitializationService', () => {
 
     it('should use default values for missing fields', async () => {
       mockAssessmentLoader.scanAssessments.mockResolvedValue(['minimal']);
-      mockAssessmentLoader.loadAssessment.mockResolvedValue({
-        // Minimal data
-      });
+        mockAssessmentLoader.loadAssessment.mockResolvedValue({
+          // Minimal data
+        } as any);
 
       // Mock getAvailableLanguages for assessments
       mockAssessmentLoader.getAvailableLanguages = jest.fn().mockResolvedValue(['en']);
       mockAssessmentLoader.getTranslatedField = jest.fn().mockReturnValue('');
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
-      mockScenarioRepo.create.mockImplementation((data) => {
+        mockScenarioRepo.create.mockImplementation((data: any) => {
         expect(data.title).toEqual({ en: 'minimal Assessment' });
         expect(data.estimatedMinutes).toBe(15);
         return Promise.resolve({ ...data, id: 'assessment-min' });
@@ -525,9 +525,9 @@ describe('ScenarioInitializationService', () => {
   describe('edge cases and helpers', () => {
     it('should handle scenario without sourceMetadata in findExistingScenario', async () => {
       mockPBLLoader.scanScenarios.mockResolvedValue(['ai_ethics']);
-      mockPBLLoader.loadScenario.mockResolvedValue({
-        scenario_info: { title: 'AI Ethics' }
-      });
+        mockPBLLoader.loadScenario.mockResolvedValue({
+          scenario_info: { title: 'AI Ethics' }
+        } as any);
 
       // Create a scenario without sourceMetadata but with matching sourcePath
       const scenarioWithoutMetadata = {
@@ -546,10 +546,10 @@ describe('ScenarioInitializationService', () => {
 
     it('should handle missing language match in Discovery path loading', async () => {
       mockDiscoveryLoader.scanPaths.mockResolvedValue(['app_developer']);
-      mockDiscoveryLoader.loadPath.mockResolvedValue({
-        metadata: { title: 'App Developer' },
-        category: 'tech'
-      });
+        mockDiscoveryLoader.loadPath.mockResolvedValue({
+          metadata: { title: 'App Developer' },
+          category: 'tech'
+        } as any);
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
       mockScenarioRepo.create.mockResolvedValue(mockDiscoveryScenario);
@@ -561,17 +561,17 @@ describe('ScenarioInitializationService', () => {
 
     it('should handle assessment with no domains', async () => {
       mockAssessmentLoader.scanAssessments.mockResolvedValue(['empty']);
-      mockAssessmentLoader.loadAssessment.mockResolvedValue({
-        metadata: { name: 'Empty Assessment' }
-        // No domains
-      });
+        mockAssessmentLoader.loadAssessment.mockResolvedValue({
+          metadata: { name: 'Empty Assessment' }
+          // No domains
+        } as any);
 
       // Mock getAvailableLanguages for assessments
       mockAssessmentLoader.getAvailableLanguages = jest.fn().mockResolvedValue(['en']);
       mockAssessmentLoader.getTranslatedField = jest.fn().mockReturnValue('');
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
-      mockScenarioRepo.create.mockImplementation((data) => {
+        mockScenarioRepo.create.mockImplementation((data: any) => {
         expect(data.taskCount).toBe(12); // Default value
         expect(data.assessmentData.totalQuestions).toBe(12); // Default value
         return Promise.resolve({ ...data, id: 'assessment-empty' });
@@ -582,13 +582,13 @@ describe('ScenarioInitializationService', () => {
 
     it('should handle PBL scenario with no programs', async () => {
       mockPBLLoader.scanScenarios.mockResolvedValue(['no_programs']);
-      mockPBLLoader.loadScenario.mockResolvedValue({
-        scenario_info: { title: 'No Programs' }
-        // No programs array
-      });
+        mockPBLLoader.loadScenario.mockResolvedValue({
+          scenario_info: { title: 'No Programs' }
+          // No programs array
+        } as any);
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
-      mockScenarioRepo.create.mockImplementation((data) => {
+        mockScenarioRepo.create.mockImplementation((data: any) => {
         expect(data.taskCount).toBe(0);
         expect(data.pblData.programs).toEqual([]);
         return Promise.resolve({ ...data, id: 'pbl-no-prog' });
@@ -601,9 +601,9 @@ describe('ScenarioInitializationService', () => {
       mockScenarioRepo.findByMode = undefined; // Method not available
 
       mockPBLLoader.scanScenarios.mockResolvedValue(['ai_ethics']);
-      mockPBLLoader.loadScenario.mockResolvedValue({
-        scenario_info: { title: 'AI Ethics' }
-      });
+        mockPBLLoader.loadScenario.mockResolvedValue({
+          scenario_info: { title: 'AI Ethics' }
+        } as any);
 
       const result = await service.initializePBLScenarios();
 
@@ -612,15 +612,15 @@ describe('ScenarioInitializationService', () => {
 
     it('should parse estimated duration correctly', async () => {
       mockPBLLoader.scanScenarios.mockResolvedValue(['test']);
-      mockPBLLoader.loadScenario.mockResolvedValue({
-        scenario_info: {
-          title: 'Test',
-          estimated_duration: '90 minutes'
-        }
-      });
+        mockPBLLoader.loadScenario.mockResolvedValue({
+          scenario_info: {
+            title: 'Test',
+            estimated_duration: '90 minutes'
+          }
+        } as any);
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
-      mockScenarioRepo.create.mockImplementation((data) => {
+        mockScenarioRepo.create.mockImplementation((data: any) => {
         expect(data.estimatedMinutes).toBe(90);
         return Promise.resolve({ ...data, id: 'pbl-test' });
       });
@@ -630,15 +630,15 @@ describe('ScenarioInitializationService', () => {
 
     it('should handle missing estimated_duration', async () => {
       mockPBLLoader.scanScenarios.mockResolvedValue(['test']);
-      mockPBLLoader.loadScenario.mockResolvedValue({
-        scenario_info: {
-          title: 'Test'
-          // No estimated_duration
-        }
-      });
+        mockPBLLoader.loadScenario.mockResolvedValue({
+          scenario_info: {
+            title: 'Test'
+            // No estimated_duration
+          }
+        } as any);
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
-      mockScenarioRepo.create.mockImplementation((data) => {
+        mockScenarioRepo.create.mockImplementation((data: any) => {
         expect(data.estimatedMinutes).toBe(60); // Default
         return Promise.resolve({ ...data, id: 'pbl-test' });
       });
@@ -676,16 +676,16 @@ describe('ScenarioInitializationService', () => {
 
     it('should handle assessment metadata with different fields', async () => {
       mockAssessmentLoader.scanAssessments.mockResolvedValue(['custom']);
-      mockAssessmentLoader.loadAssessment.mockResolvedValue({
-        metadata: {
-          name: 'Custom Assessment',
-          purpose: 'Custom purpose',
-          duration: '45 minutes' // Will be ignored, use default
-        },
-        questionBankByLanguage: {
-          en: { domains: [{ questions: [{}, {}] }] }
-        }
-      });
+        mockAssessmentLoader.loadAssessment.mockResolvedValue({
+          metadata: {
+            name: 'Custom Assessment',
+            purpose: 'Custom purpose',
+            duration: '45 minutes' // Will be ignored, use default
+          },
+          questionBankByLanguage: {
+            en: { domains: [{ questions: [{}, {}] }] }
+          }
+        } as any);
 
       // Mock getAvailableLanguages for assessments
       mockAssessmentLoader.getAvailableLanguages = jest.fn().mockResolvedValue(['en']);
@@ -696,7 +696,7 @@ describe('ScenarioInitializationService', () => {
       });
 
       mockScenarioRepo.findByMode.mockResolvedValue([]);
-      mockScenarioRepo.create.mockImplementation((data) => {
+        mockScenarioRepo.create.mockImplementation((data: any) => {
         expect(data.description).toEqual({ en: 'Custom purpose' });
         expect(data.taskCount).toBe(12); // Default value when no domains at root level
         return Promise.resolve({ ...data, id: 'assessment-custom' });

--- a/frontend/src/lib/services/__tests__/user-data-service-client.test.ts
+++ b/frontend/src/lib/services/__tests__/user-data-service-client.test.ts
@@ -33,32 +33,28 @@ describe('UserDataServiceClient', () => {
   const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
 
   const mockUserData: UserData = {
-    achievements: {
-      badges: ['first-assessment'],
-      totalXp: 100,
-      level: 2,
-      completedTasks: ['task-1', 'task-2']
-    },
+      achievements: {
+        badges: [],
+        totalXp: 100,
+        level: 2,
+        completedTasks: ['task-1', 'task-2']
+      },
     assessmentSessions: [
-      {
-        id: 'session-1',
-        scenarioId: 'ai-literacy',
-        startedAt: '2024-01-20T10:00:00Z',
-        completedAt: '2024-01-20T10:30:00Z',
-        results: {
-          totalQuestions: 20,
-          correctAnswers: 18,
-          score: 90,
-          domains: {}
+        {
+          id: 'session-1',
+          createdAt: '2024-01-20T10:00:00Z',
+          results: {
+            tech: 50,
+            creative: 40,
+            business: 30
+          }
         }
-      }
     ],
-    assessmentResults: {
-      totalQuestions: 20,
-      correctAnswers: 18,
-      score: 90,
-      domains: {}
-    },
+      assessmentResults: {
+        tech: 50,
+        creative: 40,
+        business: 30
+      },
     lastUpdated: '2024-01-20T10:30:00Z',
     version: '2.0'
   };
@@ -270,28 +266,30 @@ describe('UserDataServiceClient', () => {
     });
 
     it('should save assessment results', async () => {
-      const newResults: AssessmentResults = {
-        totalQuestions: 30,
-        correctAnswers: 28,
-        score: 93,
-        domains: { AI_Ethics: 95 }
-      };
+        const newResults: AssessmentResults = {
+          tech: 80,
+          creative: 70,
+          business: 60
+        };
 
-      await service.saveAssessmentResults(newResults);
+        await service.saveAssessmentResults(newResults);
 
-      expect(mockFetch).toHaveBeenCalledWith('/api/user-data', expect.objectContaining({
-        method: 'POST',
-        body: expect.stringContaining('"score":93')
-      }));
+        expect(mockFetch).toHaveBeenCalledWith(
+          '/api/user-data',
+          expect.objectContaining({
+            method: 'POST',
+            body: expect.stringContaining('"tech":80')
+          })
+        );
     });
 
     it('should save achievements', async () => {
-      const newAchievements: UserAchievements = {
-        badges: ['master-learner'],
-        totalXp: 500,
-        level: 5,
-        completedTasks: ['task-1', 'task-2', 'task-3']
-      };
+        const newAchievements: UserAchievements = {
+          badges: [],
+          totalXp: 500,
+          level: 5,
+          completedTasks: ['task-1', 'task-2', 'task-3']
+        };
 
       await service.saveAchievements(newAchievements);
 
@@ -302,18 +300,15 @@ describe('UserDataServiceClient', () => {
     });
 
     it('should add assessment session', async () => {
-      const newSession: AssessmentSession = {
-        id: 'session-2',
-        scenarioId: 'ai-ethics',
-        startedAt: '2024-01-21T10:00:00Z',
-        completedAt: '2024-01-21T10:45:00Z',
-        results: {
-          totalQuestions: 25,
-          correctAnswers: 23,
-          score: 92,
-          domains: {}
-        }
-      };
+        const newSession: AssessmentSession = {
+          id: 'session-2',
+          createdAt: '2024-01-21T10:00:00Z',
+          results: {
+            tech: 60,
+            creative: 55,
+            business: 70
+          }
+        };
 
       await service.addAssessmentSession(newSession);
 


### PR DESCRIPTION
## Summary
- align test mocks with updated user data and scenario types
- add explicit typings and casts to satisfy TypeScript in repository and service tests
- clean up scenario initialization and media repository tests

## Testing
- `npm run typecheck`
- `npm test` *(fails: /api/pbl/generate-feedback, /api/discovery/scenarios/[id]/programs, AuthContext, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68906a254b48833388802e940e68407d