### PR TITLE
refactor: fuzzy PBL evaluation scoring display

### DIFF
--- a/frontend/public/locales/en/pbl.json
+++ b/frontend/public/locales/en/pbl.json
@@ -283,6 +283,11 @@
     "interactions": "interactions",
     "yourAnswer": "Your Answer",
     "aiFeedback": "AI Feedback",
+    "rating": {
+      "good": "Good",
+      "great": "Great",
+      "perfect": "Perfect"
+    },
     "certificate": {
       "title": "Certificate of Completion",
       "certifies": "This is to certify that",

--- a/frontend/public/locales/zhTW/pbl.json
+++ b/frontend/public/locales/zhTW/pbl.json
@@ -283,6 +283,11 @@
     "interactions": "次互動",
     "yourAnswer": "你的回答",
     "aiFeedback": "AI 回饋",
+    "rating": {
+      "good": "良好",
+      "great": "優秀",
+      "perfect": "完美"
+    },
     "certificate": {
       "title": "完課證書",
       "certifies": "茲證明",


### PR DESCRIPTION
Replace precise percentages with qualitative ratings to reduce performance anxiety:
- Overall score: Display "Good/Great/Perfect" instead of percentage
- Domain & KSA scores: Show star ratings (1-3 stars) instead of percentages
- Remove all progress bars
- Backend data remains unchanged (0-100 numeric scores)

Score mapping:
- 0-70: Good (良好) / 1 star
- 71-90: Great (優秀) / 2 stars
- 91-100: Perfect (完美) / 3 stars

🤖 AI Assistant: Claude Sonnet 4.5
📊 Session context: ~95000 tokens
🎯 Task complexity: medium
📁 Files changed: 3