### PR TITLE
Fix: Hide demo credentials in production

### DIFF
--- a/frontend/src/components/auth/LoginForm.test.tsx
+++ b/frontend/src/components/auth/LoginForm.test.tsx
@@ -392,5 +392,29 @@ describe('LoginForm 組件測試', () => {
       expect(screen.queryByRole('button', { name: 'Teacher' })).not.toBeInTheDocument()
       expect(screen.queryByRole('button', { name: 'Admin' })).not.toBeInTheDocument()
     })
+
+    it('🔴 RED: 應該在 production 環境隱藏 placeholder 中的測試帳密', () => {
+      process.env.NEXT_PUBLIC_APP_URL = 'https://aisquare-production.web.app'
+      renderWithProviders(<LoginForm onSubmit={mockOnSubmit} />)
+
+      const emailInput = screen.getByLabelText('email') as HTMLInputElement
+      const passwordInput = screen.getByLabelText('password') as HTMLInputElement
+
+      // Production 環境不應該顯示測試帳密作為 placeholder
+      expect(emailInput.placeholder).not.toBe('student@example.com')
+      expect(passwordInput.placeholder).not.toBe('student123')
+    })
+
+    it('應該在 development 環境可以顯示 placeholder 提示', () => {
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3001'
+      renderWithProviders(<LoginForm onSubmit={mockOnSubmit} />)
+
+      const emailInput = screen.getByLabelText('email') as HTMLInputElement
+      const passwordInput = screen.getByLabelText('password') as HTMLInputElement
+
+      // Development 可以有提示，但不一定要是測試帳密
+      expect(emailInput.placeholder).toBeDefined()
+      expect(passwordInput.placeholder).toBeDefined()
+    })
   })
 })

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -29,6 +29,10 @@ export function LoginForm({ onSubmit, loading = false, error }: LoginFormProps) 
   const isStaging = appUrl.includes('staging') || appUrl.includes('aisquare-staging')
   const shouldShowDemoAccounts = isLocalhost || isStaging
 
+  // Placeholder 根據環境決定
+  const emailPlaceholder = shouldShowDemoAccounts ? 'student@example.com' : 'your-email@example.com'
+  const passwordPlaceholder = shouldShowDemoAccounts ? 'student123' : '••••••••'
+
   // 示範帳號資料
   const demoAccounts = [
     { email: 'student@example.com', password: 'student123', label: 'Student', role: 'student' },
@@ -108,7 +112,7 @@ export function LoginForm({ onSubmit, loading = false, error }: LoginFormProps) 
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors text-gray-900 bg-white"
-            placeholder="student@example.com"
+            placeholder={emailPlaceholder}
             required
             disabled={loading}
           />
@@ -128,7 +132,7 @@ export function LoginForm({ onSubmit, loading = false, error }: LoginFormProps) 
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors text-gray-900 bg-white"
-            placeholder="student123"
+            placeholder={passwordPlaceholder}
             required
             disabled={loading}
           />


### PR DESCRIPTION
## 📋 Summary

Fixes the security issue where test credentials were exposed in production environment through input placeholders.

Related to #27

## 🔧 Changes

### LoginForm Component (`src/components/auth/LoginForm.tsx`)
- Added environment-aware placeholder logic
- `emailPlaceholder`: Production shows `your-email@example.com`, Dev/Staging shows `student@example.com`
- `passwordPlaceholder`: Production shows `••••••••`, Dev/Staging shows `student123`
- Demo account buttons remain unchanged (only visible in Dev/Staging)

### Tests (`src/components/auth/LoginForm.test.tsx`)
- Added test: "🔴 RED: 應該在 production 環境隱藏 placeholder 中的測試帳密"
- Added test: "應該在 development 環境可以顯示 placeholder 提示"
- All 28 tests passing ✅

## 🧪 TDD Process

✅ **Red Phase**: Wrote failing test confirming placeholder leaks credentials
✅ **Green Phase**: Implemented environment-aware placeholders
✅ **Refactor Phase**: All tests passing, code clean

## 🔍 Root Cause Analysis

**Why 1**: Input placeholders hardcoded test credentials
**Why 2**: Convenience during development
**Why 3**: No environment-based control for placeholders
**Why 4**: `shouldShowDemoAccounts` only controlled demo buttons, not placeholders
**Why 5 (Root)**: Lack of unified environment control strategy

## ✅ Verification

- [x] All unit tests passing (28/28)
- [x] TypeScript compilation successful
- [x] No ESLint errors
- [ ] Manual testing in staging environment (待 deploy)
- [ ] Case owner approval

## 📸 Before/After

**Before**: Production login shows `student@example.com` and `student123` as placeholders
**After**: Production shows generic `your-email@example.com` and `••••••••`

## 🎯 Impact

- **Security**: ✅ No credential hints in production
- **UX**: ✅ Maintains helpful hints in development
- **Backward Compatibility**: ✅ No breaking changes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Happy](https://happy.engineering)