### PR TITLE
Fix #37: 日期格式 locale 錯誤

### DIFF
--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,1 @@
+// Issue #37 preview trigger - 2026年 1月10日 週六 13時02分39秒 CST


### PR DESCRIPTION
## Related Issue
Related to #37

## 修復內容
日期格式 locale 錯誤修復

## 測試狀態
✅ 用戶確認：「ok! 可以正確查看課程」

---
🤖 補建 PR 記錄