### PR TITLE
fix: resolve 429 rate limit exhaustion on AI routes (#82)

### DIFF
--- a/frontend/src/app/api/pbl/chat/__tests__/route.test.ts
+++ b/frontend/src/app/api/pbl/chat/__tests__/route.test.ts
@@ -17,6 +17,11 @@ import {
   mockConsoleLog,
 } from "@/test-utils/helpers/console";
 
+// Mock rate limiter to always allow in tests
+jest.mock("@/lib/api/optimization-utils", () => ({
+  rateLimit: () => () => ({ allowed: true }),
+}));
+
 // Mock dependencies
 jest.mock("@/lib/auth/unified-auth");
 jest.mock("@/lib/repositories/base/repository-factory", () => ({

--- a/frontend/src/app/api/pbl/chat/route.ts
+++ b/frontend/src/app/api/pbl/chat/route.ts
@@ -3,6 +3,9 @@ import { VertexAI } from "@google-cloud/vertexai";
 import { ErrorResponse } from "@/types/api";
 import { ChatMessage } from "@/types/pbl-api";
 import { getUnifiedAuth } from "@/lib/auth/unified-auth";
+import { rateLimit } from "@/lib/api/optimization-utils";
+
+const chatRateLimit = rateLimit(60000, 30); // 30 requests per minute per IP
 
 interface ChatRequestBody {
   message: string;
@@ -20,6 +23,17 @@ interface ChatRequestBody {
 
 export async function POST(request: NextRequest) {
   try {
+    const rateLimitResult = chatRateLimit(request);
+    if (!rateLimitResult.allowed) {
+      return NextResponse.json<ErrorResponse>(
+        { error: "AI 服務忙碌中，請稍後再試" },
+        {
+          status: 429,
+          headers: { "Retry-After": String(rateLimitResult.retryAfter ?? 60) },
+        },
+      );
+    }
+
     const body: ChatRequestBody = await request.json();
     const { message, sessionId, context } = body;
 
@@ -167,15 +181,31 @@ export async function POST(request: NextRequest) {
         sessionId,
       });
     } catch (vertexError) {
+      const vertexErrMsg =
+        vertexError instanceof Error ? vertexError.message : "";
       console.error("Vertex AI error:", {
         error: vertexError,
-        message: (vertexError as Error).message,
-        stack: (vertexError as Error).stack,
+        message: vertexErrMsg,
+        stack: vertexError instanceof Error ? vertexError.stack : undefined,
         projectId,
         aiModule,
       });
+
+      const isQuotaExhausted =
+        vertexErrMsg.includes("RESOURCE_EXHAUSTED") ||
+        vertexErrMsg.includes("429") ||
+        vertexErrMsg.includes("Quota exceeded") ||
+        vertexErrMsg.includes("rate limit");
+
+      if (isQuotaExhausted) {
+        return NextResponse.json<ErrorResponse>(
+          { error: "AI 服務忙碌中，請稍後再試" },
+          { status: 429, headers: { "Retry-After": "60" } },
+        );
+      }
+
       return NextResponse.json<ErrorResponse>(
-        { error: `AI generation failed: ${(vertexError as Error).message}` },
+        { error: `AI generation failed: ${vertexErrMsg}` },
         { status: 500 },
       );
     }

--- a/frontend/src/app/api/pbl/evaluate/__tests__/route.test.ts
+++ b/frontend/src/app/api/pbl/evaluate/__tests__/route.test.ts
@@ -3,6 +3,11 @@ import { POST } from "../route";
 import { VertexAI } from "@google-cloud/vertexai";
 import { getUnifiedAuth } from "@/lib/auth/unified-auth";
 
+// Mock rate limiter to always allow in tests
+jest.mock("@/lib/api/optimization-utils", () => ({
+  rateLimit: () => () => ({ allowed: true }),
+}));
+
 // Mock unified auth
 jest.mock("@/lib/auth/unified-auth", () => ({
   getUnifiedAuth: jest.fn(),

--- a/frontend/src/app/api/pbl/evaluate/route.ts
+++ b/frontend/src/app/api/pbl/evaluate/route.ts
@@ -4,9 +4,26 @@ import { EvaluateRequestBody, Conversation } from "@/types/pbl-evaluate";
 import { ErrorResponse } from "@/types/api";
 import { getUnifiedAuth } from "@/lib/auth/unified-auth";
 import { LANGUAGE_NAMES } from "@/lib/utils/language";
+import { rateLimit } from "@/lib/api/optimization-utils";
+
+const evaluateRateLimit = rateLimit(60000, 10); // 10 requests per minute per IP
 
 export async function POST(request: NextRequest) {
   try {
+    // Apply rate limiting to protect AI quota
+    const rateLimitResult = evaluateRateLimit(request);
+    if (!rateLimitResult.allowed) {
+      return NextResponse.json<ErrorResponse>(
+        { error: "AI 服務忙碌中，請稍後再試" },
+        {
+          status: 429,
+          headers: {
+            "Retry-After": String(rateLimitResult.retryAfter ?? 60),
+          },
+        },
+      );
+    }
+
     // Use unified authentication
     const session = await getUnifiedAuth(request);
 
@@ -212,7 +229,7 @@ For Simplified Chinese (简体中文), use Simplified Chinese ONLY.`,
       ],
       generationConfig: {
         temperature: 0.7,
-        maxOutputTokens: 65535,
+        maxOutputTokens: 8192,
         responseMimeType: "application/json",
         responseSchema: {
           type: SchemaType.OBJECT,
@@ -403,12 +420,22 @@ For Simplified Chinese (简体中文), use Simplified Chinese ONLY.`,
   } catch (error) {
     console.error("Error in evaluation:", error);
 
-    // Provide more detailed error information
-    let errorMessage = "Failed to evaluate";
-    const statusCode = 500;
+    const errorMessage =
+      error instanceof Error ? error.message : "Failed to evaluate";
+    const isQuotaExhausted =
+      errorMessage.includes("RESOURCE_EXHAUSTED") ||
+      errorMessage.includes("429") ||
+      errorMessage.includes("Quota exceeded") ||
+      errorMessage.includes("rate limit");
+
+    if (isQuotaExhausted) {
+      return NextResponse.json(
+        { success: false, error: "AI 服務忙碌中，請稍後再試" },
+        { status: 429, headers: { "Retry-After": "60" } },
+      );
+    }
 
     if (error instanceof Error) {
-      errorMessage = error.message;
       console.error("Error details:", error.stack);
     }
 
@@ -418,7 +445,7 @@ For Simplified Chinese (简体中文), use Simplified Chinese ONLY.`,
         error: errorMessage,
         details: process.env.NODE_ENV === "development" ? error : undefined,
       },
-      { status: statusCode },
+      { status: 500 },
     );
   }
 }

--- a/frontend/src/app/api/pbl/generate-feedback/__tests__/route.test.ts
+++ b/frontend/src/app/api/pbl/generate-feedback/__tests__/route.test.ts
@@ -22,6 +22,11 @@ import type {
 } from "@/types/unified-learning";
 import { mockConsoleError, mockConsoleLog } from "@/test-utils/helpers/console";
 
+// Mock rate limiter to always allow in tests
+jest.mock("@/lib/api/optimization-utils", () => ({
+  rateLimit: () => () => ({ allowed: true }),
+}));
+
 // Unmock unified-auth to use actual implementation but with our explicit mocks
 jest.unmock("@/lib/auth/unified-auth");
 // Mock dependencies
@@ -984,7 +989,7 @@ describe("POST /api/pbl/generate-feedback", () => {
           ]),
           generationConfig: expect.objectContaining({
             temperature: 0.7,
-            maxOutputTokens: 65535,
+            maxOutputTokens: 8192,
             responseMimeType: "application/json",
             responseSchema: expect.any(Object),
           }),

--- a/frontend/src/app/api/pbl/generate-feedback/route.ts
+++ b/frontend/src/app/api/pbl/generate-feedback/route.ts
@@ -6,6 +6,9 @@ import {
 } from "@/lib/auth/unified-auth";
 import { getLanguageFromHeader, LANGUAGE_NAMES } from "@/lib/utils/language";
 import { Task, Evaluation } from "@/lib/repositories/interfaces";
+import { rateLimit } from "@/lib/api/optimization-utils";
+
+const generateFeedbackRateLimit = rateLimit(60000, 10); // 10 requests per minute per IP
 
 // Types for feedback structure
 interface FeedbackStrength {
@@ -179,6 +182,17 @@ You must always respond with a valid JSON object following the exact schema prov
 
 export async function POST(request: NextRequest) {
   try {
+    const rateLimitResult = generateFeedbackRateLimit(request);
+    if (!rateLimitResult.allowed) {
+      return NextResponse.json(
+        { success: false, error: "AI 服務忙碌中，請稍後再試" },
+        {
+          status: 429,
+          headers: { "Retry-After": String(rateLimitResult.retryAfter ?? 60) },
+        },
+      );
+    }
+
     const {
       programId,
       scenarioId,
@@ -531,7 +545,7 @@ Do not mix languages. The entire response must be in ${LANGUAGE_NAMES[currentLan
       contents: [{ role: "user", parts: [{ text: prompt }] }],
       generationConfig: {
         temperature: 0.7,
-        maxOutputTokens: 65535, // Increased token limit
+        maxOutputTokens: 8192,
         responseMimeType: "application/json",
         responseSchema: feedbackSchema,
       },
@@ -682,6 +696,21 @@ Do not mix languages. The entire response must be in ${LANGUAGE_NAMES[currentLan
     });
   } catch (error) {
     console.error("Error generating feedback:", error);
+
+    const errMsg = error instanceof Error ? error.message : "";
+    const isQuotaExhausted =
+      errMsg.includes("RESOURCE_EXHAUSTED") ||
+      errMsg.includes("429") ||
+      errMsg.includes("Quota exceeded") ||
+      errMsg.includes("rate limit");
+
+    if (isQuotaExhausted) {
+      return NextResponse.json(
+        { success: false, error: "AI 服務忙碌中，請稍後再試" },
+        { status: 429, headers: { "Retry-After": "60" } },
+      );
+    }
+
     return NextResponse.json(
       { success: false, error: "Failed to generate feedback" },
       { status: 500 },

--- a/frontend/src/app/api/pbl/tasks/[taskId]/translate-evaluation/route.ts
+++ b/frontend/src/app/api/pbl/tasks/[taskId]/translate-evaluation/route.ts
@@ -5,6 +5,9 @@ import {
 } from "@/lib/auth/unified-auth";
 import { getLanguageFromHeader, LANGUAGE_NAMES } from "@/lib/utils/language";
 import { VertexAI } from "@google-cloud/vertexai";
+import { rateLimit } from "@/lib/api/optimization-utils";
+
+const translateRateLimit = rateLimit(60000, 10); // 10 requests per minute per IP
 
 // POST - Translate existing evaluation to current language
 export async function POST(
@@ -12,6 +15,17 @@ export async function POST(
   { params }: { params: Promise<{ taskId: string }> },
 ) {
   try {
+    const rateLimitResult = translateRateLimit(request);
+    if (!rateLimitResult.allowed) {
+      return NextResponse.json(
+        { success: false, error: "AI 服務忙碌中，請稍後再試" },
+        {
+          status: 429,
+          headers: { "Retry-After": String(rateLimitResult.retryAfter ?? 60) },
+        },
+      );
+    }
+
     // Get user session
     const session = await getUnifiedAuth(request);
     if (!session?.user?.email) {
@@ -163,6 +177,21 @@ Return the same JSON structure with all text translated.`;
       });
     } catch (error) {
       console.error("Translation failed:", error);
+
+      const errMsg = error instanceof Error ? error.message : "";
+      const isQuotaExhausted =
+        errMsg.includes("RESOURCE_EXHAUSTED") ||
+        errMsg.includes("429") ||
+        errMsg.includes("Quota exceeded") ||
+        errMsg.includes("rate limit");
+
+      if (isQuotaExhausted) {
+        return NextResponse.json(
+          { success: false, error: "AI 服務忙碌中，請稍後再試" },
+          { status: 429, headers: { "Retry-After": "60" } },
+        );
+      }
+
       return NextResponse.json(
         { success: false, error: "Failed to translate evaluation" },
         { status: 500 },

--- a/frontend/src/app/pbl/scenarios/[id]/programs/[programId]/complete/page.tsx
+++ b/frontend/src/app/pbl/scenarios/[id]/programs/[programId]/complete/page.tsx
@@ -107,6 +107,7 @@ export default function ProgramCompletePage() {
     scenarioTitle,
     feedback,
     generatingFeedback,
+    feedbackError,
     allTasksEvaluated,
     formatDuration,
     generateFeedback,
@@ -233,6 +234,7 @@ export default function ProgramCompletePage() {
               isGenerating={generatingFeedback}
               onRegenerate={() => generateFeedback(true)}
               showDevControls={process.env.NODE_ENV === "development"}
+              error={feedbackError}
             />
 
             {/* Three Column Layout - Score Cards */}

--- a/frontend/src/components/pbl/complete/QualitativeFeedbackSection.tsx
+++ b/frontend/src/components/pbl/complete/QualitativeFeedbackSection.tsx
@@ -15,6 +15,7 @@ interface QualitativeFeedbackSectionProps {
   isGenerating: boolean;
   onRegenerate?: () => void;
   showDevControls?: boolean;
+  error?: string | null;
 }
 
 export function QualitativeFeedbackSection({
@@ -22,10 +23,11 @@ export function QualitativeFeedbackSection({
   isGenerating,
   onRegenerate,
   showDevControls = false,
+  error,
 }: QualitativeFeedbackSectionProps) {
   const { t } = useTranslation(["pbl"]);
 
-  if (!feedback?.overallAssessment && !isGenerating) {
+  if (!feedback?.overallAssessment && !isGenerating && !error) {
     return null;
   }
 
@@ -39,6 +41,19 @@ export function QualitativeFeedbackSection({
               "pbl:complete.generatingFeedback",
               "Generating personalized feedback..."
             )}
+          </p>
+        </div>
+      ) : error ? (
+        <div className="text-center py-4">
+          <p className="text-amber-600 dark:text-amber-400">
+            {error.includes("429") ||
+            error.includes("忙碌") ||
+            error.includes("RESOURCE_EXHAUSTED")
+              ? t("pbl:complete.aiBusy", "AI 服務忙碌中，請稍後再試")
+              : t(
+                  "pbl:complete.feedbackUnavailable",
+                  "Feedback temporarily unavailable. Please try again later."
+                )}
           </p>
         </div>
       ) : feedback ? (

--- a/frontend/src/hooks/use-program-completion.ts
+++ b/frontend/src/hooks/use-program-completion.ts
@@ -25,6 +25,7 @@ export interface UseProgramCompletionReturn {
   scenarioTitle: string;
   feedback: QualitativeFeedback | undefined;
   generatingFeedback: boolean;
+  feedbackError: string | null;
   allTasksEvaluated: boolean;
   formatDuration: (seconds: number) => string;
   generateFeedback: (forceRegenerate?: boolean) => Promise<void>;
@@ -40,11 +41,13 @@ export function useProgramCompletion({
   const [completionData, setCompletionData] = useState<CompletionData | null>(null);
   const [scenarioData, setScenarioData] = useState<ScenarioData | null>(null);
   const [generatingFeedback, setGeneratingFeedback] = useState(false);
+  const [feedbackError, setFeedbackError] = useState<string | null>(null);
 
   // Refs for preventing duplicate API calls
   const loadingRef = useRef(false);
   const feedbackGeneratingRef = useRef(false);
   const isMountedRef = useRef(false);
+  const feedbackDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Check if all tasks are evaluated
   const allTasksEvaluated = completionData
@@ -120,6 +123,7 @@ export function useProgramCompletion({
 
       try {
         setGeneratingFeedback(true);
+        setFeedbackError(null);
 
         const response = await authenticatedFetch("/api/pbl/generate-feedback", {
           method: "POST",
@@ -176,6 +180,9 @@ export function useProgramCompletion({
         }
       } catch (error) {
         console.error("Error generating feedback:", error);
+        const errMsg =
+          error instanceof Error ? error.message : "Failed to generate feedback";
+        setFeedbackError(errMsg);
       } finally {
         setGeneratingFeedback(false);
         feedbackGeneratingRef.current = false;
@@ -299,7 +306,16 @@ export function useProgramCompletion({
       !feedbackGeneratingRef.current &&
       !generatingFeedback
     ) {
-      generateFeedback();
+      // Debounce to prevent rapid language switches from spawning multiple AI calls
+      if (feedbackDebounceRef.current) {
+        clearTimeout(feedbackDebounceRef.current);
+      }
+      setFeedbackError(null);
+      feedbackDebounceRef.current = setTimeout(() => {
+        if (!feedbackGeneratingRef.current) {
+          generateFeedback();
+        }
+      }, 500);
     }
   }, [
     i18n.language,
@@ -319,6 +335,7 @@ export function useProgramCompletion({
     scenarioTitle,
     feedback,
     generatingFeedback,
+    feedbackError,
     allTasksEvaluated,
     formatDuration,
     generateFeedback,

--- a/frontend/src/hooks/use-task-evaluation.ts
+++ b/frontend/src/hooks/use-task-evaluation.ts
@@ -101,7 +101,7 @@ export function useTaskEvaluation({
   }, [conversations, taskId, programId, currentTask, i18n.language]);
 
   const handleEvaluate = async () => {
-    if (!currentTask || conversations.length === 0) return;
+    if (!currentTask || conversations.length === 0 || isEvaluating) return;
 
     setIsEvaluating(true);
 
@@ -130,6 +130,11 @@ export function useTaskEvaluation({
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
         console.error("Evaluation API error:", errorData);
+        if (response.status === 429) {
+          throw new Error(
+            errorData.error || "AI 服務忙碌中，請稍後再試",
+          );
+        }
         throw new Error(
           errorData.error || `HTTP ${response.status}: Failed to evaluate`,
         );


### PR DESCRIPTION
## Summary
- Reduce `maxOutputTokens` 65535→8192 on evaluate and generate-feedback routes (8x reduction)
- Add `rateLimit()` guard to all AI routes: evaluate (10rpm), generate-feedback (10rpm), chat (30rpm), translate-evaluation (10rpm)
- Add double-click/re-entrancy guard on evaluate button (desktop + mobile)
- Fix completion page: AI failure no longer blocks certificate tab
- Add 500ms debounce on language-switch feedback generation
- Return user-friendly 429 "AI 服務忙碌中，請稍後再試" with Retry-After header
- Update tests to mock rate limiter and reflect new maxOutputTokens

## Root Cause
Vertex AI quota (RPM) exhausted due to:
1. `maxOutputTokens: 65535` consuming massive throughput per request
2. No application-level rate limiting on any AI route
3. No debounce on evaluate button (double-clicks = double API calls)
4. Completion page auto-triggering AI on every load + language switch

## Test plan
- [x] TypeScript: zero errors
- [x] ESLint: no new warnings
- [x] Unit tests: 5048 passed, 0 failed
- [ ] Deploy to staging and verify AI endpoints respond correctly
- [ ] Verify certificate tab works even when AI quota exhausted

Closes #82

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)