### PR TITLE
fix: resolve chat and feedback 500 errors on production

### DIFF
--- a/frontend/src/app/api/pbl/chat/route.ts
+++ b/frontend/src/app/api/pbl/chat/route.ts
@@ -248,7 +248,7 @@ Current Task: ${taskTitle}
 Description: ${taskDescription}
 
 Task Instructions:
-${instructions.map((inst, i) => `${i + 1}. ${inst}`).join("\n")}
+${(instructions || []).map((inst: string, i: number) => `${i + 1}. ${inst}`).join("\n")}
 
 Expected Outcome: ${expectedOutcome}
 

--- a/frontend/src/app/api/pbl/generate-feedback/route.ts
+++ b/frontend/src/app/api/pbl/generate-feedback/route.ts
@@ -256,12 +256,12 @@ export async function POST(request: NextRequest) {
     }
 
     if (!evaluation) {
-      // Trigger evaluation calculation if needed
-      const completeUrl = new URL(
-        `/api/pbl/programs/${programId}/complete`,
-        request.url,
-      );
-      const completeRes = await fetch(completeUrl.toString(), {
+      // Call the complete endpoint internally
+      // Use localhost to avoid Cloud Run self-referential HTTP issues
+      const port = process.env.PORT || "3000";
+      const internalBaseUrl = `http://localhost:${port}`;
+      const completeUrl = `${internalBaseUrl}/api/pbl/programs/${programId}/complete`;
+      const completeRes = await fetch(completeUrl, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
Follow-up to PR #83 (429 rate limit fix). Found two additional 500 errors during production API testing:

1. **Chat 500** (`TypeError: Cannot read properties of undefined (reading 'map')`)
   - `context.instructions` is undefined when client doesn't send it
   - Fix: `(instructions || []).map(...)` fallback

2. **Generate-feedback 500** (`TypeError: fetch failed`)
   - Self-referential HTTP call to public URL fails on Cloud Run
   - Fix: Use `http://localhost:${PORT}` for internal API calls

## Test plan
- [x] TypeScript: zero errors
- [x] Unit tests: 5065 passed, 0 failed
- [ ] Deploy and test chat endpoint with real auth
- [ ] Deploy and test generate-feedback endpoint with real auth

Related to #82

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)