### PR TITLE
fix(security): lock Discovery on production #87

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -20,6 +20,18 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // Block discovery routes on production to prevent AI quota abuse
+  // Discovery AI chat/evaluation has no per-user rate limit yet
+  const isProduction = process.env.NODE_ENV === "production" &&
+    !request.nextUrl.hostname.includes("staging") &&
+    !request.nextUrl.hostname.includes("preview");
+  if (isProduction && (pathname.startsWith("/discovery") || pathname.startsWith("/api/discovery"))) {
+    if (pathname.startsWith("/api/")) {
+      return NextResponse.json({ error: "Discovery is temporarily unavailable" }, { status: 503 });
+    }
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
   // Handle API routes with rate limiting
   const isApiRoute = pathname.startsWith("/api/");
   if (isApiRoute) {


### PR DESCRIPTION
## Summary
- Block `/discovery/*` page routes on production (redirect to homepage)
- Block `/api/discovery/*` API routes on production (return 503)
- Staging and preview environments are unaffected
- This is a temporary measure until per-user rate limits are implemented

## Why
Discovery module has 4 AI API endpoints calling Vertex AI Gemini with zero rate limiting. Any user can exhaust our quota.

## Test plan
- [ ] Production: `/discovery` redirects to `/`
- [ ] Production: `/api/discovery/chat` returns 503
- [ ] Staging: `/discovery` works normally
- [ ] Preview: `/discovery` works normally

Closes #87