### PR TITLE
feat(discovery): integration fixes + i18n + banner (#106)

### DIFF
--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -27,7 +27,7 @@ model User {
   level                  Int          @default(1)
   totalXp                Int          @default(0) @map("total_xp")
   achievements           Json         @default("[]")
-  skills                 Json         @default("[]")
+  skills                 Json         @default("{}")
   lastLoginAt            DateTime?    @map("last_login_at")
   lastActiveDate         DateTime?    @map("last_active_date") @db.Date
   createdAt              DateTime     @default(now()) @map("created_at")

--- a/frontend/public/locales/en/discovery.json
+++ b/frontend/public/locales/en/discovery.json
@@ -434,6 +434,7 @@
     "loading": "Loading...",
     "notFound": "Scenario not found",
     "backToScenarios": "Back to Scenarios",
+    "backToList": "Back to Career List",
     "myPrograms": "My Programs",
     "startNewProgram": "Start New Program",
     "creating": "Creating...",
@@ -447,7 +448,13 @@
     "salary": "Salary Range",
     "requiredSkills": "Required Skills",
     "technical": "Technical",
-    "soft": "Soft Skills"
+    "soft": "Soft Skills",
+    "loadingPrograms": "Loading programs...",
+    "learningJourney": "Learning Journey #{{n}}",
+    "startedOn": "Started",
+    "completedOn": "Completed",
+    "taskCount": "tasks",
+    "completed": "completed"
   },
 
   "skillTree": {
@@ -485,5 +492,100 @@
     "scaffolding": "Guided Mode",
     "targetSkills": "Target Skills",
     "nextTask": "Generate Next Task"
+  },
+
+  "scenarios": {
+    "heading": "Explore Career Adventures",
+    "subheading": "Choose your career role and begin a unique learning adventure. Each career has carefully designed story scenarios and challenge tasks.",
+    "tabAll": "All",
+    "tabMy": "My Adventures",
+    "labelIndustry": "Industry",
+    "labelJobFunction": "Function",
+    "loadingAll": "Loading career adventures...",
+    "loadingMy": "Loading my learning journeys...",
+    "emptyMyTitle": "No learning journeys started yet",
+    "emptyMySubtitle": "Choose a career path and start your exploration journey",
+    "browseAll": "Browse All Careers",
+    "emptyFiltered": "No career adventures found matching your criteria",
+    "filters": {
+      "all": "All",
+      "technology": "Tech / AI",
+      "arts": "Creative / Media",
+      "business": "Business / Startup",
+      "hardware": "Semiconductor / Hardware",
+      "science": "Science / Biotech",
+      "green": "Energy / Sustainability",
+      "automation": "Automation / Transport",
+      "engineer": "Engineer",
+      "designer": "Designer",
+      "researcher": "Researcher",
+      "creator": "Creator",
+      "pm": "PM / Management",
+      "businessFunc": "Business / Startup"
+    }
+  },
+
+  "program": {
+    "notFound": "Learning journey not found",
+    "backToScenario": "Back to Career Detail",
+    "tasks": "Learning Tasks",
+    "taskLabel": "Task {{n}}",
+    "attempts": "{{count}} attempts",
+    "passes": "{{count}} passes",
+    "completedOn": "Completed on",
+    "start": "Start",
+    "view": "View",
+    "allCompleted": "Congratulations, all tasks completed!",
+    "allCompletedDesc": "You have completed all tasks in this learning journey and earned {{xp}} XP!",
+    "viewFullResults": "View Full Results",
+    "startNew": "Start New Journey"
+  },
+
+  "dailyLimit": {
+    "title": "Daily AI usage limit reached",
+    "description": "Your daily AI interaction quota (200,000 tokens per day) has been used up. The quota resets at UTC midnight tomorrow. Come back tomorrow to continue learning!"
+  },
+
+  "careers": {
+    "content_creator": {
+      "title": "Digital Magician - Content Creator",
+      "skills": ["Content Magic", "Visual Spells", "Text Alchemy", "Community Summoning"]
+    },
+    "youtuber": {
+      "title": "Stellar Broadcaster - YouTuber",
+      "skills": ["Stellar Editing", "Audience Psychology", "Cosmic Trend Prediction", "Cross-Galaxy Broadcasting"]
+    },
+    "app_developer": {
+      "title": "Digital Architect - App Developer",
+      "skills": ["Code Magic", "Interface Sculpting", "Logic Engineering", "System Alchemy"]
+    },
+    "game_designer": {
+      "title": "Dream Weaver - Game Designer",
+      "skills": ["Dream Weaving", "Emotional Tuning", "Balance Laws", "Psychological Alchemy"]
+    },
+    "tech_entrepreneur": {
+      "title": "Spacetime Business Traveler - Tech Entrepreneur",
+      "skills": ["Spacetime Business Insight", "Cross-Dimensional Tech Integration", "Team Summoning", "Innovation Prophecy"]
+    },
+    "startup_founder": {
+      "title": "Business Adventurer - Startup Founder",
+      "skills": ["Business Intuition", "Market Exploration", "Resource Alchemy", "Risk Navigation"]
+    },
+    "data_analyst": {
+      "title": "Digital Archaeologist - Data Analyst",
+      "skills": ["Digital Archaeology", "Pattern Recognition", "Visualization Magic", "Insight Prophecy"]
+    },
+    "ux_designer": {
+      "title": "Experience Architect - UX Designer",
+      "skills": ["User Psychology", "Experience Magic", "Prototype Sculpting", "Communication Art"]
+    },
+    "product_manager": {
+      "title": "Product Commander - Product Manager",
+      "skills": ["Strategic Vision", "Needs Insight", "Resource Allocation", "Team Coordination"]
+    },
+    "ai_developer": {
+      "title": "Machine Soul Forger - AI Developer",
+      "skills": ["Soul Coding", "Neural Network Magic", "Intelligence Art", "Future Deployment"]
+    }
   }
 }

--- a/frontend/public/locales/zhTW/discovery.json
+++ b/frontend/public/locales/zhTW/discovery.json
@@ -459,7 +459,13 @@
     "salary": "薪資範圍",
     "requiredSkills": "所需技能",
     "technical": "技術技能",
-    "soft": "軟技能"
+    "soft": "軟技能",
+    "loadingPrograms": "載入學習歷程中...",
+    "learningJourney": "學習歷程 #{{n}}",
+    "startedOn": "開始於",
+    "completedOn": "完成於",
+    "taskCount": "個任務",
+    "completed": "完成"
   },
 
   "skillTree": {
@@ -497,5 +503,102 @@
     "scaffolding": "引導模式",
     "targetSkills": "目標技能",
     "nextTask": "生成下一個任務"
+  },
+
+  "scenarios": {
+    "heading": "探索職業冒險",
+    "subheading": "選擇你的職業角色，開始獨特的學習冒險。每個職業都有精心設計的故事情境和挑戰任務。",
+    "tabAll": "全部",
+    "tabMy": "我的冒險",
+    "labelIndustry": "產業",
+    "labelJobFunction": "職能",
+    "loadingAll": "載入職業冒險中...",
+    "loadingMy": "載入我的學習歷程...",
+    "emptyMyTitle": "還沒有開始任何學習歷程",
+    "emptyMySubtitle": "選擇一個職業路徑，開始你的探索之旅",
+    "browseAll": "瀏覽所有職業",
+    "emptyFiltered": "沒有找到符合條件的職業冒險",
+    "filters": {
+      "all": "全部",
+      "technology": "科技 / AI",
+      "arts": "創意 / 媒體",
+      "business": "商業 / 創業",
+      "hardware": "半導體 / 硬體",
+      "science": "科學 / 生技",
+      "green": "能源 / 永續",
+      "automation": "自動化 / 交通",
+      "engineer": "工程師",
+      "designer": "設計師",
+      "researcher": "研究員",
+      "creator": "創作者",
+      "pm": "PM / 管理",
+      "businessFunc": "商業 / 創業"
+    }
+  },
+
+
+
+  "program": {
+    "notFound": "找不到此學習歷程",
+    "backToScenario": "返回職業詳情",
+    "tasks": "學習任務",
+    "taskLabel": "任務 {{n}}",
+    "attempts": "{{count}}次嘗試",
+    "passes": "{{count}}次通過",
+    "completedOn": "完成於",
+    "start": "開始",
+    "view": "檢視",
+    "allCompleted": "恭喜完成所有任務！",
+    "allCompletedDesc": "你已經完成了這個學習歷程的所有任務，獲得了 {{xp}} XP！",
+    "viewFullResults": "查看完整結果",
+    "startNew": "開始新的歷程"
+  },
+
+  "dailyLimit": {
+    "title": "今日 AI 使用額度已達上限",
+    "description": "你今天的 AI 互動額度（每日 200,000 tokens）已用完。額度將於明天 UTC 午夜重置，請明天再來繼續學習！📚"
+  },
+
+  "careers": {
+    "content_creator": {
+      "title": "數位魔法師 - 內容創作者",
+      "skills": ["內容魔法", "視覺咒語", "文字煉金術", "社群召喚術"]
+    },
+    "youtuber": {
+      "title": "星際廣播員 - YouTuber",
+      "skills": ["星際剪輯術", "觀眾心理學", "宇宙趨勢預測", "跨星系傳播"]
+    },
+    "app_developer": {
+      "title": "數碼建築師 - 應用程式開發者",
+      "skills": ["程式魔法", "介面雕塑", "邏輯工程", "系統煉金術"]
+    },
+    "game_designer": {
+      "title": "夢境織夢師 - 遊戲設計師",
+      "skills": ["夢境編織", "情感調律", "平衡法則", "心理煉金術"]
+    },
+    "tech_entrepreneur": {
+      "title": "時空商業旅行者 - 科技創業家",
+      "skills": ["時空商業洞察", "跨維度技術整合", "團隊召喚術", "創新預言術"]
+    },
+    "startup_founder": {
+      "title": "商業冒險家 - 創業家",
+      "skills": ["商業嗅覺", "市場探勘", "資源煉金術", "風險航海術"]
+    },
+    "data_analyst": {
+      "title": "數位考古學家 - 數據分析師",
+      "skills": ["數位考古術", "模式識別術", "視覺化魔法", "洞察預言術"]
+    },
+    "ux_designer": {
+      "title": "体驗建築師 - UX 設計師",
+      "skills": ["用户心理学", "体験魔法", "原型雕塑", "沟通艺术"]
+    },
+    "product_manager": {
+      "title": "產品指揮官 - 產品經理",
+      "skills": ["策略视野", "需求洞察", "資源配置", "團隊协調"]
+    },
+    "ai_developer": {
+      "title": "機器靈魂鍛造師 - AI 開發者",
+      "skills": ["靈魂編碼術", "神經網絡魔法", "智慧藝術", "未來部署術"]
+    }
   }
 }

--- a/frontend/src/app/api/discovery/chat/route.ts
+++ b/frontend/src/app/api/discovery/chat/route.ts
@@ -1,5 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
 import { VertexAI } from "@google-cloud/vertexai";
+import { getUnifiedAuth } from "@/lib/auth/unified-auth";
+import { repositoryFactory } from "@/lib/repositories/base/repository-factory";
+import { checkRateLimit } from "@/lib/middleware/rate-limit";
+import {
+  hasTokenBudget,
+  recordTokenUsage,
+} from "@/lib/middleware/ai-token-tracker";
+
+// Per-user rate limit: 10 requests per minute
+const DISCOVERY_CHAT_RATE_LIMIT = {
+  maxRequests: 10,
+  windowMs: 60_000,
+  message:
+    "你發送訊息太頻繁了，請稍等 1 分鐘後再試。(Rate limit: 10 requests/min)",
+};
 
 export async function POST(request: NextRequest) {
   try {
@@ -9,8 +24,64 @@ export async function POST(request: NextRequest) {
     if (!message || !context) {
       return NextResponse.json(
         { error: "Message and context are required" },
-        { status: 400 },
+        { status: 400 }
       );
+    }
+
+    // Authenticate user for per-user limits
+    const session = await getUnifiedAuth(request);
+    let userId: string | null = null;
+
+    if (session?.user?.email) {
+      try {
+        const userRepo = repositoryFactory.getUserRepository();
+        const user = await userRepo.findByEmail(session.user.email);
+        if (user) {
+          userId = user.id;
+        }
+      } catch (err) {
+        console.warn("[Discovery Chat] Could not resolve user for limits:", err);
+      }
+    }
+
+    // Per-user rate limit (10 req/min)
+    if (userId) {
+      const rateLimitKey = `discovery-chat:${userId}`;
+      const rateLimitResult = checkRateLimit(
+        rateLimitKey,
+        DISCOVERY_CHAT_RATE_LIMIT
+      );
+      if (!rateLimitResult.allowed) {
+        return NextResponse.json(
+          {
+            error: "Too Many Requests",
+            message: DISCOVERY_CHAT_RATE_LIMIT.message,
+            retryAfter: rateLimitResult.retryAfter,
+          },
+          {
+            status: 429,
+            headers: {
+              "Retry-After": String(rateLimitResult.retryAfter ?? 60),
+              "X-RateLimit-Limit": String(DISCOVERY_CHAT_RATE_LIMIT.maxRequests),
+              "X-RateLimit-Remaining": "0",
+            },
+          }
+        );
+      }
+    }
+
+    // Per-user daily token budget check
+    if (userId) {
+      const budgetOk = await hasTokenBudget(userId);
+      if (!budgetOk) {
+        return NextResponse.json(
+          {
+            response:
+              "你今天的 AI 使用額度已用完（每日上限 200,000 tokens）。額度將於明天 UTC 午夜重置，請明天再來繼續學習！📚",
+          },
+          { status: 200 } // Return 200 to avoid breaking UI, same as other errors here
+        );
+      }
     }
 
     // Build the system prompt with context
@@ -83,6 +154,17 @@ Please respond as the AI ${context.aiRole} in Traditional Chinese, being helpful
       throw new Error("No response generated");
     }
 
+    // Record token usage asynchronously (non-blocking)
+    if (userId) {
+      const usageMetadata = response.usageMetadata;
+      const tokensUsed =
+        usageMetadata?.totalTokenCount ||
+        Math.ceil((message.length + text.length) / 4);
+      recordTokenUsage(userId, tokensUsed).catch((err) =>
+        console.warn("[Discovery Chat] Token tracking failed:", err)
+      );
+    }
+
     return NextResponse.json({ response: text });
   } catch (error) {
     console.error("AI chat error:", error);
@@ -93,7 +175,7 @@ Please respond as the AI ${context.aiRole} in Traditional Chinese, being helpful
         response:
           "抱歉，我暫時無法處理你的訊息。請稍後再試，或者繼續探索當前的任務！💪",
       },
-      { status: 200 }, // Return 200 to avoid breaking the UI
+      { status: 200 } // Return 200 to avoid breaking the UI
     );
   }
 }

--- a/frontend/src/app/api/discovery/programs/[programId]/next-task/route.ts
+++ b/frontend/src/app/api/discovery/programs/[programId]/next-task/route.ts
@@ -8,6 +8,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { repositoryFactory } from "@/lib/repositories/base/repository-factory";
 import { getUnifiedAuth, createUnauthorizedResponse } from "@/lib/auth/unified-auth";
 import { AdaptiveTaskGenerator } from "@/lib/services/discovery/adaptive-task-generator";
+import { hasTokenBudget, recordTokenUsage } from "@/lib/middleware/ai-token-tracker";
 
 export async function POST(
   request: NextRequest,
@@ -46,10 +47,22 @@ export async function POST(
       );
     }
 
+    // Check daily token budget before calling AI
+    const budgetOk = await hasTokenBudget(user.id);
+    if (!budgetOk) {
+      return NextResponse.json(
+        { error: "您今日的 AI 使用額度已用完，請明天再試" },
+        { status: 429, headers: { "Retry-After": "3600" } },
+      );
+    }
+
     // Generate adaptive task
     const generator = new AdaptiveTaskGenerator();
     const targetSkillId = await generator.selectTargetSkill(user.id, careerId, language);
     const generatedTask = await generator.generateTask(user.id, careerId, targetSkillId, language);
+
+    // Record estimated token usage (~2000 tokens per task generation)
+    await recordTokenUsage(user.id, 2000);
 
     // Create the task in DB
     const taskRepo = repositoryFactory.getTaskRepository();

--- a/frontend/src/app/api/discovery/scenarios/[id]/start/route.ts
+++ b/frontend/src/app/api/discovery/scenarios/[id]/start/route.ts
@@ -7,6 +7,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { learningServiceFactory } from "@/lib/services/learning-service-factory";
 import { repositoryFactory } from "@/lib/repositories/base/repository-factory";
 import { getUnifiedAuth } from "@/lib/auth/unified-auth";
+import {
+  checkAndIncrementSession,
+  DAILY_SESSION_LIMIT,
+} from "@/lib/middleware/ai-token-tracker";
 
 export async function POST(
   request: NextRequest,
@@ -91,6 +95,21 @@ export async function POST(
     }
 
     console.log("   User ID:", user.id);
+
+    // Check per-user daily session limit
+    const sessionCheck = await checkAndIncrementSession(user.id);
+    if (!sessionCheck.allowed) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `每日探索方案上限已達到（每天最多 ${DAILY_SESSION_LIMIT} 個新方案）。請明天再來繼續學習！`,
+          errorCode: "SESSION_LIMIT_EXCEEDED",
+          sessionsRemaining: 0,
+        },
+        { status: 429 }
+      );
+    }
+
     console.log("   Using Discovery Learning Service to start learning...");
 
     // Use the new service layer

--- a/frontend/src/app/api/discovery/user/budget/route.ts
+++ b/frontend/src/app/api/discovery/user/budget/route.ts
@@ -1,0 +1,47 @@
+/**
+ * GET /api/discovery/user/budget
+ *
+ * Returns the current user's daily AI token budget status.
+ * Response: { remaining, limit, sessionsRemaining, resetAt }
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getUnifiedAuth } from "@/lib/auth/unified-auth";
+import { repositoryFactory } from "@/lib/repositories/base/repository-factory";
+import { getBudgetStatus } from "@/lib/middleware/ai-token-tracker";
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getUnifiedAuth(request);
+    if (!session?.user?.email) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const userRepo = repositoryFactory.getUserRepository();
+    const user = await userRepo.findByEmail(session.user.email);
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const status = await getBudgetStatus(user.id);
+
+    return NextResponse.json({
+      remaining: status.tokensRemaining,
+      limit: status.tokensLimit,
+      sessionsRemaining: status.sessionsRemaining,
+      sessionsLimit: status.sessionsLimit,
+      resetAt: status.resetAt,
+      tokensUsed: status.tokensUsed,
+      sessionsStarted: status.sessionsStarted,
+    });
+  } catch (error) {
+    console.error("[Budget API] Error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch budget status" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/app/api/pbl/chat/route.ts
+++ b/frontend/src/app/api/pbl/chat/route.ts
@@ -3,7 +3,8 @@ import { VertexAI } from "@google-cloud/vertexai";
 import { ErrorResponse } from "@/types/api";
 import { ChatMessage } from "@/types/pbl-api";
 import { getUnifiedAuth } from "@/lib/auth/unified-auth";
-import { rateLimit, checkTokenBudget, recordTokenUsage } from "@/lib/api/optimization-utils";
+import { rateLimit, checkTokenBudget } from "@/lib/api/optimization-utils";
+import { recordTokenUsage as recordTokenUsageDB } from "@/lib/middleware/ai-token-tracker";
 
 const chatRateLimit = rateLimit(60000, 30); // 30 requests per minute per IP
 
@@ -189,7 +190,7 @@ export async function POST(request: NextRequest) {
       const usage = response.usageMetadata;
       if (usage) {
         const totalTokens = (usage.promptTokenCount || 0) + (usage.candidatesTokenCount || 0);
-        recordTokenUsage(totalTokens, session.user.id);
+        await recordTokenUsageDB(session.user.id, totalTokens);
       }
 
       return NextResponse.json({

--- a/frontend/src/app/api/pbl/evaluate/route.ts
+++ b/frontend/src/app/api/pbl/evaluate/route.ts
@@ -4,7 +4,8 @@ import { EvaluateRequestBody, Conversation } from "@/types/pbl-evaluate";
 import { ErrorResponse } from "@/types/api";
 import { getUnifiedAuth } from "@/lib/auth/unified-auth";
 import { LANGUAGE_NAMES } from "@/lib/utils/language";
-import { rateLimit, checkTokenBudget, recordTokenUsage } from "@/lib/api/optimization-utils";
+import { rateLimit, checkTokenBudget } from "@/lib/api/optimization-utils";
+import { recordTokenUsage as recordTokenUsageDB } from "@/lib/middleware/ai-token-tracker";
 
 const evaluateRateLimit = rateLimit(60000, 10); // 10 requests per minute per IP
 
@@ -346,7 +347,7 @@ For Simplified Chinese (简体中文), use Simplified Chinese ONLY.`,
     const usage = response.usageMetadata;
     if (usage) {
       const totalTokens = (usage.promptTokenCount || 0) + (usage.candidatesTokenCount || 0);
-      recordTokenUsage(totalTokens, session.user.id);
+      await recordTokenUsageDB(session.user.id, totalTokens);
     }
 
     // Parse JSON response - should be clean JSON due to responseSchema

--- a/frontend/src/app/api/pbl/generate-feedback/route.ts
+++ b/frontend/src/app/api/pbl/generate-feedback/route.ts
@@ -6,7 +6,8 @@ import {
 } from "@/lib/auth/unified-auth";
 import { getLanguageFromHeader, LANGUAGE_NAMES } from "@/lib/utils/language";
 import { Task, Evaluation } from "@/lib/repositories/interfaces";
-import { rateLimit, checkTokenBudget, recordTokenUsage } from "@/lib/api/optimization-utils";
+import { rateLimit, checkTokenBudget } from "@/lib/api/optimization-utils";
+import { recordTokenUsage as recordTokenUsageDB } from "@/lib/middleware/ai-token-tracker";
 
 const generateFeedbackRateLimit = rateLimit(60000, 10); // 10 requests per minute per IP
 
@@ -566,7 +567,7 @@ Do not mix languages. The entire response must be in ${LANGUAGE_NAMES[currentLan
     const usage = response.usageMetadata;
     if (usage) {
       const totalTokens = (usage.promptTokenCount || 0) + (usage.candidatesTokenCount || 0);
-      recordTokenUsage(totalTokens, user.id);
+      await recordTokenUsageDB(user.id, totalTokens);
     }
 
     const feedbackText =

--- a/frontend/src/app/discovery/achievements/page.tsx
+++ b/frontend/src/app/discovery/achievements/page.tsx
@@ -4,13 +4,19 @@ import React from "react";
 import dynamic from "next/dynamic";
 import DiscoveryPageLayout from "@/components/discovery/DiscoveryPageLayout";
 import { useDiscoveryData } from "@/hooks/useDiscoveryData";
+import { useTranslation } from "react-i18next";
+
+function AchievementsLoadingFallback() {
+  const { t } = useTranslation("discovery");
+  return <div className="text-center py-8">{t("scenarioDetail.loading")}</div>;
+}
 
 // Dynamic import to avoid SSR issues
 const AchievementsView = dynamic(
   () => import("@/components/discovery/AchievementsView"),
   {
     ssr: false,
-    loading: () => <div className="text-center py-8">載入中...</div>,
+    loading: AchievementsLoadingFallback,
   },
 );
 

--- a/frontend/src/app/discovery/scenarios/[id]/page.tsx
+++ b/frontend/src/app/discovery/scenarios/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
+import Image from "next/image";
 import {
   Sparkles,
   Rocket,
@@ -78,6 +79,7 @@ interface ScenarioData {
   mode: string;
   difficulty: string;
   estimatedMinutes: number;
+  sourceId?: string;
   discoveryData?: {
     pathId?: string;
     category?: string;
@@ -190,8 +192,9 @@ export default function DiscoveryScenarioDetailPage({
         // Get session token from localStorage for API calls
         const sessionToken = localStorage.getItem("ai_square_session");
 
+        const lang = normalizeLanguageCode(i18n.language);
         const response = await authenticatedFetch(
-          `/api/discovery/scenarios/${scenarioId}`,
+          `/api/discovery/scenarios/${scenarioId}?lang=${lang}`,
           {
             credentials: "include",
             headers: {
@@ -250,7 +253,7 @@ export default function DiscoveryScenarioDetailPage({
       const lang = normalizeLanguageCode(i18n.language);
 
       const response = await authenticatedFetch(
-        `/api/discovery/scenarios/${scenarioId}/programs`,
+        `/api/discovery/scenarios/${scenarioId}/start`,
         {
           method: "POST",
           headers: {
@@ -329,6 +332,7 @@ export default function DiscoveryScenarioDetailPage({
     careerColors[careerType as keyof typeof careerColors] ||
     "from-gray-500 to-gray-600";
   const skills = (scenarioData.metadata?.skillFocus || []) as string[];
+  const bannerImage = `/images/discovery-banners/${scenarioData.sourceId || careerType}.webp`;
 
   return (
     <DiscoveryPageLayout>
@@ -344,8 +348,20 @@ export default function DiscoveryScenarioDetailPage({
 
         {/* Career Header */}
         <div className="bg-white rounded-2xl shadow-lg overflow-hidden mb-8">
-          <div className={`h-48 bg-gradient-to-br ${color} relative`}>
-            <div className="absolute inset-0 bg-black/10"></div>
+          <div className={`h-48 bg-gradient-to-br ${color} relative overflow-hidden`}>
+            <Image
+              src={bannerImage}
+              alt={scenarioData.title}
+              fill
+              className="object-cover"
+              sizes="(max-width: 768px) 100vw, 800px"
+              onError={(e) => {
+                // Fallback to gradient + icon if image not found
+                (e.target as HTMLImageElement).style.display = "none";
+              }}
+            />
+            {/* Fallback icon (visible when image fails to load) */}
+            <div className="absolute inset-0 bg-black/10" />
             <div className="absolute inset-0 flex items-center justify-center">
               <Icon className="w-24 h-24 text-white/90" />
             </div>
@@ -409,7 +425,7 @@ export default function DiscoveryScenarioDetailPage({
           {loadingPrograms ? (
             <div className="text-center py-8">
               <div className="animate-spin h-8 w-8 border-2 border-purple-600 border-t-transparent rounded-full mx-auto"></div>
-              <p className="mt-2 text-gray-600">Loading programs...</p>
+              <p className="mt-2 text-gray-600">{t("discovery:scenarioDetail.loadingPrograms")}</p>
             </div>
           ) : programs.length > 0 ? (
             <div className="grid gap-4 mt-6">
@@ -428,7 +444,7 @@ export default function DiscoveryScenarioDetailPage({
                       <div className="flex items-center space-x-3">
                         <h3 className="text-lg font-semibold text-gray-900">
                           {program.status === "completed" ? "✅ " : "🚀 "}
-                          Learning Journey #{programs.indexOf(program) + 1}
+                          {t("discovery:scenarioDetail.learningJourney", { n: programs.indexOf(program) + 1 })}
                         </h3>
                         <span
                           className={`px-2 py-1 text-xs rounded-full ${
@@ -437,20 +453,22 @@ export default function DiscoveryScenarioDetailPage({
                               : "bg-blue-100 text-blue-700"
                           }`}
                         >
-                          {program.status}
+                          {program.status === "completed"
+                            ? t("discovery:programCard.statusCompleted")
+                            : t("discovery:programCard.statusActive")}
                         </span>
                       </div>
                       <p className="text-sm text-gray-600 mt-1">
-                        Started{" "}
+                        {t("discovery:scenarioDetail.startedOn")}{" "}
                         {new Date(program.createdAt).toLocaleDateString()}
                         {program.completedAt &&
-                          ` • Completed ${new Date(program.completedAt).toLocaleDateString()}`}
+                          ` • ${t("discovery:scenarioDetail.completedOn")} ${new Date(program.completedAt).toLocaleDateString()}`}
                       </p>
                       <div className="flex items-center space-x-4 mt-2 text-sm text-gray-600">
                         <span>💎 {program.metadata?.totalXP || 0} XP</span>
                         <span>
                           📊 {program.metadata?.completedTasks || 0}/
-                          {program.metadata?.totalTasks || 6} 個任務
+                          {program.metadata?.totalTasks || 6} {t("discovery:scenarioDetail.taskCount")}
                         </span>
                         {program.metadata?.completedTasks &&
                           program.metadata?.totalTasks && (
@@ -461,7 +479,7 @@ export default function DiscoveryScenarioDetailPage({
                                   program.metadata.totalTasks) *
                                   100,
                               )}
-                              % 完成)
+                              % {t("discovery:scenarioDetail.completed")})
                             </span>
                           )}
                       </div>

--- a/frontend/src/app/discovery/scenarios/[id]/programs/[programId]/__tests__/page.test.tsx
+++ b/frontend/src/app/discovery/scenarios/[id]/programs/[programId]/__tests__/page.test.tsx
@@ -25,7 +25,21 @@ jest.mock("@/contexts/AuthContext", () => ({
 }));
 jest.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string, opts?: Record<string, unknown>) => {
+      // Return arrays for skills keys so .map() works
+      if (opts?.returnObjects && key.endsWith(".skills")) {
+        return ["skill1", "skill2"];
+      }
+      // Return interpolated keys for templates
+      if (opts && typeof opts === "object") {
+        let result = key;
+        for (const [k, v] of Object.entries(opts)) {
+          if (k !== "returnObjects") result += ` ${v}`;
+        }
+        return result.trim();
+      }
+      return key;
+    },
     i18n: {
       language: "en",
       changeLanguage: jest.fn(),
@@ -137,7 +151,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.queryByText("scenarioDetail.loading")).not.toBeInTheDocument();
         },
         { timeout: 3000 },
       );
@@ -150,7 +164,7 @@ describe("ProgramDetailPage", () => {
 
     it("should show loading state initially", async () => {
       renderWithProviders(<ProgramDetailPage params={createMockParams()} />);
-      expect(screen.getByText("載入中...")).toBeInTheDocument();
+      expect(screen.getByText("scenarioDetail.loading")).toBeInTheDocument();
     });
 
     it("should redirect to login when not authenticated", async () => {
@@ -182,7 +196,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          const element = screen.queryByText("找不到此學習歷程");
+          const element = screen.queryByText("program.notFound");
           if (element) expect(element).toBeInTheDocument();
         },
         { timeout: 1000 },
@@ -197,19 +211,17 @@ describe("ProgramDetailPage", () => {
       // Wait for loading to finish
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.queryByText("scenarioDetail.loading")).not.toBeInTheDocument();
         },
         { timeout: 3000 },
       );
 
-      // Check all career-related content
+      // Check career title (i18n mock returns key)
       await waitFor(
         () => {
-          expect(screen.getByText("數位魔法師 - 內容創作者")).toBeInTheDocument();
-          expect(screen.getByText("內容魔法")).toBeInTheDocument();
-          expect(screen.getByText("視覺咒語")).toBeInTheDocument();
-          expect(screen.getByText("文字煉金術")).toBeInTheDocument();
-          expect(screen.getByText("社群召喚術")).toBeInTheDocument();
+          expect(screen.getByText("careers.content_creator.title")).toBeInTheDocument();
+          // Skills are returned as ["skill1", "skill2"] by the mock
+          expect(screen.getAllByText("skill1").length).toBeGreaterThan(0);
         },
         { timeout: 2000 },
       );
@@ -231,7 +243,7 @@ describe("ProgramDetailPage", () => {
       // Wait for loading to finish
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.queryByText("scenarioDetail.loading")).not.toBeInTheDocument();
         },
         { timeout: 3000 },
       );
@@ -239,9 +251,7 @@ describe("ProgramDetailPage", () => {
       // Check all YouTuber career content
       await waitFor(
         () => {
-          expect(screen.getByText("星際廣播員 - YouTuber")).toBeInTheDocument();
-          expect(screen.getByText("星際剪輯術")).toBeInTheDocument();
-          expect(screen.getByText("觀眾心理學")).toBeInTheDocument();
+          expect(screen.getByText("careers.youtuber.title")).toBeInTheDocument();
         },
         { timeout: 2000 },
       );
@@ -274,24 +284,21 @@ describe("ProgramDetailPage", () => {
     it("should render all tasks with correct status", async () => {
       renderWithProviders(<ProgramDetailPage params={createMockParams()} />);
 
-      // Wait for loading to finish
+      // Wait for data to load and tasks to appear
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.getByText(/understand_algorithms/i)).toBeInTheDocument();
         },
-        { timeout: 3000 },
+        { timeout: 5000 },
       );
 
       // Check all tasks and XP values
+      expect(screen.getByText(/learn_content_basics/i)).toBeInTheDocument();
+      expect(screen.getByText(/advanced_techniques/i)).toBeInTheDocument();
+
+      // Check XP values
       await waitFor(
         () => {
-          // Tasks are rendered as "任務 1: <title>", "任務 2: <title>", etc.
-          expect(screen.getByText(/任務 1:/)).toBeInTheDocument();
-          expect(screen.getByText(/understand_algorithms/i)).toBeInTheDocument();
-          expect(screen.getByText(/learn_content_basics/i)).toBeInTheDocument();
-          expect(screen.getByText(/advanced_techniques/i)).toBeInTheDocument();
-
-          // Check XP values - use getAllByText for multiple occurrences
           expect(screen.getAllByText("95 XP")[0]).toBeInTheDocument();
           expect(screen.getByText("100 XP")).toBeInTheDocument();
           expect(screen.getByText("120 XP")).toBeInTheDocument();
@@ -305,7 +312,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.queryByText("scenarioDetail.loading")).not.toBeInTheDocument();
         },
         { timeout: 3000 },
       );
@@ -319,7 +326,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          const element = screen.queryByText(/完成於/);
+          const element = screen.queryByText(/program.completedOn/);
           if (element) expect(element).toBeInTheDocument();
         },
         { timeout: 1000 },
@@ -347,7 +354,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.queryByText("scenarioDetail.loading")).not.toBeInTheDocument();
         },
         { timeout: 3000 },
       );
@@ -363,7 +370,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.queryByText("scenarioDetail.loading")).not.toBeInTheDocument();
         },
         { timeout: 3000 },
       );
@@ -377,7 +384,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.queryByText("scenarioDetail.loading")).not.toBeInTheDocument();
         },
         { timeout: 3000 },
       );
@@ -391,7 +398,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.queryByText("scenarioDetail.loading")).not.toBeInTheDocument();
         },
         { timeout: 3000 },
       );
@@ -409,7 +416,7 @@ describe("ProgramDetailPage", () => {
         expect(screen.getByText("33%")).toBeInTheDocument(); // 1/3 = 33%
       });
 
-      expect(screen.getByText(/1 \/ 3/)).toBeInTheDocument();
+      expect(screen.getByText(/programCard\.tasksCompleted/)).toBeInTheDocument();
     });
 
     it("should handle zero progress", async () => {
@@ -428,7 +435,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.queryByText("scenarioDetail.loading")).not.toBeInTheDocument();
         },
         { timeout: 3000 },
       );
@@ -459,7 +466,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.queryByText("scenarioDetail.loading")).not.toBeInTheDocument();
         },
         { timeout: 3000 },
       );
@@ -492,7 +499,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.queryByText("scenarioDetail.loading")).not.toBeInTheDocument();
         },
         { timeout: 3000 },
       );
@@ -521,7 +528,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.queryByText("scenarioDetail.loading")).not.toBeInTheDocument();
         },
         { timeout: 3000 },
       );
@@ -537,7 +544,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          expect(screen.queryByText("載入中...")).not.toBeInTheDocument();
+          expect(screen.queryByText("scenarioDetail.loading")).not.toBeInTheDocument();
         },
         { timeout: 3000 },
       );
@@ -553,7 +560,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          const element = screen.queryByText("進行中");
+          const element = screen.queryByText("programCard.statusActive");
           if (element) expect(element).toBeInTheDocument();
         },
         { timeout: 1000 },
@@ -575,7 +582,7 @@ describe("ProgramDetailPage", () => {
 
       await waitFor(
         () => {
-          const element = screen.queryByText("已完成");
+          const element = screen.queryByText("programCard.statusCompleted");
           if (element) expect(element).toBeInTheDocument();
         },
         { timeout: 1000 },

--- a/frontend/src/app/discovery/scenarios/[id]/programs/[programId]/page.tsx
+++ b/frontend/src/app/discovery/scenarios/[id]/programs/[programId]/page.tsx
@@ -57,7 +57,7 @@ export default function ProgramDetailPage({
   params: Promise<{ id: string; programId: string }>;
 }) {
   const router = useRouter();
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation("discovery");
   const { isLoggedIn, isLoading: authLoading } = useAuth();
   const [loading, setLoading] = useState(true);
   const [programData, setProgramData] = useState<ProgramData | null>(null);
@@ -130,7 +130,7 @@ export default function ProgramDetailPage({
         <div className="max-w-4xl mx-auto px-4 py-16 text-center">
           <div className="inline-flex items-center space-x-2 text-gray-500">
             <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-purple-600"></div>
-            <span>載入中...</span>
+            <span>{t("scenarioDetail.loading")}</span>
           </div>
         </div>
       </DiscoveryPageLayout>
@@ -141,12 +141,12 @@ export default function ProgramDetailPage({
     return (
       <DiscoveryPageLayout>
         <div className="max-w-4xl mx-auto px-4 py-16 text-center">
-          <p className="text-gray-500">找不到此學習歷程</p>
+          <p className="text-gray-500">{t("program.notFound")}</p>
           <button
             onClick={() => router.push(`/discovery/scenarios/${scenarioId}`)}
             className="mt-4 text-purple-600 hover:text-purple-700"
           >
-            返回職業詳情
+            {t("program.backToScenario")}
           </button>
         </div>
       </DiscoveryPageLayout>
@@ -169,64 +169,64 @@ export default function ProgramDetailPage({
     }
   > = {
     content_creator: {
-      title: "數位魔法師 - 內容創作者",
+      title: t("careers.content_creator.title"),
       icon: Paintbrush,
       color: "from-purple-500 to-pink-500",
-      skills: ["內容魔法", "視覺咒語", "文字煉金術", "社群召喚術"],
+      skills: t("careers.content_creator.skills", { returnObjects: true }) as string[],
     },
     youtuber: {
-      title: "星際廣播員 - YouTuber",
+      title: t("careers.youtuber.title"),
       icon: Video,
       color: "from-red-500 to-orange-500",
-      skills: ["星際剪輯術", "觀眾心理學", "宇宙趨勢預測", "跨星系傳播"],
+      skills: t("careers.youtuber.skills", { returnObjects: true }) as string[],
     },
     app_developer: {
-      title: "數碼建築師 - 應用程式開發者",
+      title: t("careers.app_developer.title"),
       icon: Code,
       color: "from-blue-500 to-cyan-500",
-      skills: ["程式魔法", "介面雕塑", "邏輯工程", "系統煉金術"],
+      skills: t("careers.app_developer.skills", { returnObjects: true }) as string[],
     },
     game_designer: {
-      title: "夢境織夢師 - 遊戲設計師",
+      title: t("careers.game_designer.title"),
       icon: Box,
       color: "from-indigo-500 to-purple-500",
-      skills: ["夢境編織", "情感調律", "平衡法則", "心理煉金術"],
+      skills: t("careers.game_designer.skills", { returnObjects: true }) as string[],
     },
     tech_entrepreneur: {
-      title: "時空商業旅行者 - 科技創業家",
+      title: t("careers.tech_entrepreneur.title"),
       icon: Rocket,
       color: "from-yellow-500 to-red-500",
-      skills: ["時空商業洞察", "跨維度技術整合", "團隊召喚術", "創新預言術"],
+      skills: t("careers.tech_entrepreneur.skills", { returnObjects: true }) as string[],
     },
     startup_founder: {
-      title: "商業冒險家 - 創業家",
+      title: t("careers.startup_founder.title"),
       icon: Briefcase,
       color: "from-green-500 to-teal-500",
-      skills: ["商業嗅覺", "市場探勘", "資源煉金術", "風險航海術"],
+      skills: t("careers.startup_founder.skills", { returnObjects: true }) as string[],
     },
     data_analyst: {
-      title: "數位考古學家 - 數據分析師",
+      title: t("careers.data_analyst.title"),
       icon: BarChart,
       color: "from-teal-500 to-blue-500",
-      skills: ["數位考古術", "模式識別術", "視覺化魔法", "洞察預言術"],
+      skills: t("careers.data_analyst.skills", { returnObjects: true }) as string[],
     },
     ux_designer: {
-      title: "体驗建築師 - UX 設計師",
+      title: t("careers.ux_designer.title"),
       icon: Sparkles,
       color: "from-pink-500 to-purple-500",
-      skills: ["用户心理学", "体験魔法", "原型雕塑", "沟通艺术"],
+      skills: t("careers.ux_designer.skills", { returnObjects: true }) as string[],
     },
     product_manager: {
-      title: "產品指揮官 - 產品經理",
+      title: t("careers.product_manager.title"),
       icon: Users,
       color: "from-orange-500 to-yellow-500",
-      skills: ["策略视野", "需求洞察", "資源配置", "團隊协調"],
+      skills: t("careers.product_manager.skills", { returnObjects: true }) as string[],
     },
     ai_developer: {
-      title: "機器靈魂鍛造師 - AI 開發者",
+      title: t("careers.ai_developer.title"),
       icon: Cpu,
       color: "from-violet-500 to-purple-500",
-      skills: ["靈魂編碼術", "神經網絡魔法", "智慧藝術", "未來部署術"],
+      skills: t("careers.ai_developer.skills", { returnObjects: true }) as string[],
     },
   };
 
@@ -247,7 +247,7 @@ export default function ProgramDetailPage({
           className="flex items-center space-x-2 text-gray-600 hover:text-gray-900 mb-6"
         >
           <ArrowLeft className="w-5 h-5" />
-          <span>返回職業詳情</span>
+          <span>{t("program.backToScenario")}</span>
         </button>
 
         {/* Career Info Card */}
@@ -283,16 +283,14 @@ export default function ProgramDetailPage({
           <div className="flex items-start justify-between mb-6">
             <div>
               <h1 className="text-3xl font-bold text-gray-900 mb-2">
-                學習歷程
+                {t("programCard.title")}
               </h1>
               <div className="flex items-center space-x-4 text-sm text-gray-600">
                 <div className="flex items-center space-x-1">
                   <Clock className="w-4 h-4" />
                   <span>
-                    開始於{" "}
-                    {new Date(programData.createdAt).toLocaleDateString(
-                      "zh-TW",
-                    )}
+                    {t("programCard.startedOn")}{" "}
+                    {new Date(programData.createdAt).toLocaleDateString()}
                   </span>
                 </div>
                 <div className="flex items-center space-x-1">
@@ -304,12 +302,12 @@ export default function ProgramDetailPage({
 
             {programData.status === "active" && (
               <span className="px-3 py-1 bg-green-100 text-green-700 text-sm rounded-full">
-                進行中
+                {t("programCard.statusActive")}
               </span>
             )}
             {programData.status === "completed" && (
               <span className="px-3 py-1 bg-blue-100 text-blue-700 text-sm rounded-full">
-                已完成
+                {t("programCard.statusCompleted")}
               </span>
             )}
           </div>
@@ -317,7 +315,7 @@ export default function ProgramDetailPage({
           {/* Progress Bar */}
           <div>
             <div className="flex items-center justify-between text-sm mb-2">
-              <span className="text-gray-600">整體進度</span>
+              <span className="text-gray-600">{t("programCard.progress")}</span>
               <span className="text-gray-900 font-medium">{progress}%</span>
             </div>
             <div className="w-full bg-gray-200 rounded-full h-3">
@@ -327,15 +325,14 @@ export default function ProgramDetailPage({
               />
             </div>
             <p className="mt-2 text-sm text-gray-500">
-              已完成 {programData.completedTasks} / {programData.totalTasks}{" "}
-              個任務
+              {t("programCard.tasksCompleted", { completed: programData.completedTasks, total: programData.totalTasks })}
             </p>
           </div>
         </div>
 
         {/* Tasks List */}
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 mb-6">學習任務</h2>
+          <h2 className="text-2xl font-bold text-gray-900 mb-6">{t("program.tasks")}</h2>
 
           <div className="space-y-4">
             {programData.tasks.map((task, index) => (
@@ -399,7 +396,7 @@ export default function ProgramDetailPage({
                           ${task.status === "completed" ? "text-gray-600" : "text-gray-900"}
                         `}
                         >
-                          任務 {index + 1}:{" "}
+                          {t("program.taskLabel", { n: index + 1 })}:{" "}
                           {typeof task.title === "object" && task.title !== null
                             ? (task.title as Record<string, string>)[
                                 normalizeLanguageCode(i18n.language)
@@ -441,14 +438,14 @@ export default function ProgramDetailPage({
                               <div className="flex items-center space-x-1">
                                 <span className="text-gray-600">📊</span>
                                 <span className="text-gray-600">
-                                  {task.attempts}次嘗試
+                                  {t("program.attempts", { count: task.attempts })}
                                 </span>
                               </div>
                               {task.passCount && task.passCount > 0 && (
                                 <div className="flex items-center space-x-1">
                                   <span className="text-gray-600">⭐</span>
                                   <span className="text-gray-600">
-                                    {task.passCount}次通過
+                                    {t("program.passes", { count: task.passCount })}
                                   </span>
                                 </div>
                               )}
@@ -457,10 +454,8 @@ export default function ProgramDetailPage({
 
                           {task.completedAt && (
                             <span className="text-green-600">
-                              完成於{" "}
-                              {new Date(task.completedAt).toLocaleDateString(
-                                "zh-TW",
-                              )}
+                              {t("program.completedOn")}{" "}
+                              {new Date(task.completedAt).toLocaleDateString()}
                             </span>
                           )}
                         </div>
@@ -472,13 +467,13 @@ export default function ProgramDetailPage({
                       (task as Task).status === "active") && (
                       <button className="flex items-center space-x-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors">
                         <Play className="w-4 h-4" />
-                        <span>開始</span>
+                        <span>{t("program.start")}</span>
                       </button>
                     )}
                     {task.status === "completed" && (
                       <button className="flex items-center space-x-2 px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors">
                         <CheckCircle className="w-4 h-4" />
-                        <span>檢視</span>
+                        <span>{t("program.view")}</span>
                       </button>
                     )}
                   </div>
@@ -494,11 +489,10 @@ export default function ProgramDetailPage({
             <div className="mt-8 bg-gradient-to-r from-purple-50 to-blue-50 rounded-xl p-8 text-center">
               <Trophy className="w-16 h-16 text-purple-600 mx-auto mb-4" />
               <h3 className="text-2xl font-bold text-gray-900 mb-2">
-                恭喜完成所有任務！
+                {t("program.allCompleted")}
               </h3>
               <p className="text-gray-600 mb-6">
-                你已經完成了這個學習歷程的所有任務，獲得了 {programData.totalXP}{" "}
-                XP！
+                {t("program.allCompletedDesc", { xp: programData.totalXP })}
               </p>
               <div className="flex justify-center space-x-4">
                 <button
@@ -510,7 +504,7 @@ export default function ProgramDetailPage({
                   className="inline-flex items-center space-x-2 px-6 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
                 >
                   <CheckCircle className="w-5 h-5" />
-                  <span>查看完整結果</span>
+                  <span>{t("program.viewFullResults")}</span>
                 </button>
                 <button
                   onClick={() =>
@@ -519,7 +513,7 @@ export default function ProgramDetailPage({
                   className="inline-flex items-center space-x-2 px-6 py-3 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors"
                 >
                   <Sparkles className="w-5 h-5" />
-                  <span>開始新的歷程</span>
+                  <span>{t("program.startNew")}</span>
                 </button>
               </div>
             </div>

--- a/frontend/src/app/discovery/scenarios/[id]/programs/[programId]/tasks/[taskId]/page.tsx
+++ b/frontend/src/app/discovery/scenarios/[id]/programs/[programId]/tasks/[taskId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import {
   Sparkles,
   CheckCircle,
@@ -79,6 +79,10 @@ export default function TaskDetailPage({
   const [scenarioId, setScenarioId] = useState<string>("");
   const [programId, setProgramId] = useState<string>("");
   const [taskId, setTaskId] = useState<string>("");
+  const [dailyLimitReached, setDailyLimitReached] = useState(false);
+
+  // Debounce ref: prevent double-click submission
+  const submitDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Unwrap the params Promise
   useEffect(() => {
@@ -160,8 +164,14 @@ export default function TaskDetailPage({
     i18n.language,
   ]);
 
-  const handleSubmit = async () => {
-    if (!userResponse.trim()) return;
+  const handleSubmit = useCallback(async () => {
+    if (!userResponse.trim() || submitting) return;
+
+    // Debounce: ignore calls within 500ms of the last call
+    if (submitDebounceRef.current) return;
+    submitDebounceRef.current = setTimeout(() => {
+      submitDebounceRef.current = null;
+    }, 500);
 
     setSubmitting(true);
     const startTime = Date.now();
@@ -185,6 +195,13 @@ export default function TaskDetailPage({
           }),
         },
       );
+
+      if (res.status === 429) {
+        // Daily token limit or rate limit exceeded
+        setDailyLimitReached(true);
+        setSubmitting(false);
+        return;
+      }
 
       if (!res.ok) {
         throw new Error("Failed to submit task");
@@ -233,7 +250,7 @@ export default function TaskDetailPage({
     } finally {
       setSubmitting(false);
     }
-  };
+  }, [userResponse, submitting, scenarioId, programId, taskId, i18n.language]);
 
   const handleCompleteTask = async () => {
     setCompletingTask(true);
@@ -476,6 +493,22 @@ export default function TaskDetailPage({
             )}
         </div>
 
+        {/* Daily limit reached banner */}
+        {dailyLimitReached && (
+          <div className="bg-amber-50 border border-amber-200 rounded-2xl p-6 mb-6 flex items-start space-x-3">
+            <AlertCircle className="w-6 h-6 text-amber-500 flex-shrink-0 mt-0.5" />
+            <div>
+              <p className="font-semibold text-amber-800">
+                今日 AI 使用額度已達上限
+              </p>
+              <p className="text-amber-700 text-sm mt-1">
+                你今天的 AI 互動額度（每日 200,000 tokens）已用完。額度將於明天
+                UTC 午夜重置，請明天再來繼續學習！📚
+              </p>
+            </div>
+          </div>
+        )}
+
         {/* Response Section - Only show if task is not completed */}
         {taskData.status !== "completed" && (
           <div className="bg-white rounded-2xl shadow-lg p-8 mb-6">
@@ -513,11 +546,11 @@ export default function TaskDetailPage({
 
               <button
                 onClick={handleSubmit}
-                disabled={!userResponse.trim() || submitting}
+                disabled={!userResponse.trim() || submitting || dailyLimitReached}
                 className={`
                   flex items-center space-x-2 px-6 py-3 rounded-lg font-medium transition-all
                   ${
-                    userResponse.trim() && !submitting
+                    userResponse.trim() && !submitting && !dailyLimitReached
                       ? "bg-purple-600 text-white hover:bg-purple-700"
                       : "bg-gray-200 text-gray-400 cursor-not-allowed"
                   }

--- a/frontend/src/app/discovery/scenarios/[id]/programs/[programId]/tasks/[taskId]/page.tsx
+++ b/frontend/src/app/discovery/scenarios/[id]/programs/[programId]/tasks/[taskId]/page.tsx
@@ -499,11 +499,10 @@ export default function TaskDetailPage({
             <AlertCircle className="w-6 h-6 text-amber-500 flex-shrink-0 mt-0.5" />
             <div>
               <p className="font-semibold text-amber-800">
-                今日 AI 使用額度已達上限
+                {t("dailyLimit.title")}
               </p>
               <p className="text-amber-700 text-sm mt-1">
-                你今天的 AI 互動額度（每日 200,000 tokens）已用完。額度將於明天
-                UTC 午夜重置，請明天再來繼續學習！📚
+                {t("dailyLimit.description")}
               </p>
             </div>
           </div>

--- a/frontend/src/app/discovery/scenarios/page.tsx
+++ b/frontend/src/app/discovery/scenarios/page.tsx
@@ -95,27 +95,27 @@ const categoryMapping: Record<string, string[]> = {
   automation: ["robotics", "autonomous_systems"],
 };
 
-// Industry filters (Row 1)
-const industryFilters = [
-  { id: "all", name: "全部", icon: Sparkles },
-  { id: "technology", name: "科技 / AI", icon: Code },
-  { id: "arts", name: "創意 / 媒體", icon: Paintbrush },
-  { id: "business", name: "商業 / 創業", icon: Briefcase },
-  { id: "hardware", name: "半導體 / 硬體", icon: CircuitBoard },
-  { id: "science", name: "科學 / 生技", icon: Lightbulb },
-  { id: "green", name: "能源 / 永續", icon: Leaf },
-  { id: "automation", name: "自動化 / 交通", icon: Bot },
+// Industry filters (Row 1) - names are i18n keys
+const industryFilterDefs = [
+  { id: "all", nameKey: "discovery:scenarios.filters.all", icon: Sparkles },
+  { id: "technology", nameKey: "discovery:scenarios.filters.technology", icon: Code },
+  { id: "arts", nameKey: "discovery:scenarios.filters.arts", icon: Paintbrush },
+  { id: "business", nameKey: "discovery:scenarios.filters.business", icon: Briefcase },
+  { id: "hardware", nameKey: "discovery:scenarios.filters.hardware", icon: CircuitBoard },
+  { id: "science", nameKey: "discovery:scenarios.filters.science", icon: Lightbulb },
+  { id: "green", nameKey: "discovery:scenarios.filters.green", icon: Leaf },
+  { id: "automation", nameKey: "discovery:scenarios.filters.automation", icon: Bot },
 ];
 
-// Job function filters (Row 2)
-const jobFunctionFilters = [
-  { id: "all", name: "全部", icon: Sparkles },
-  { id: "engineer", name: "工程師", icon: Cpu },
-  { id: "designer", name: "設計師", icon: Paintbrush },
-  { id: "researcher", name: "研究員", icon: Lightbulb },
-  { id: "creator", name: "創作者", icon: Video },
-  { id: "pm", name: "PM / 管理", icon: Users },
-  { id: "business", name: "商業 / 創業", icon: Briefcase },
+// Job function filters (Row 2) - names are i18n keys
+const jobFunctionFilterDefs = [
+  { id: "all", nameKey: "discovery:scenarios.filters.all", icon: Sparkles },
+  { id: "engineer", nameKey: "discovery:scenarios.filters.engineer", icon: Cpu },
+  { id: "designer", nameKey: "discovery:scenarios.filters.designer", icon: Paintbrush },
+  { id: "researcher", nameKey: "discovery:scenarios.filters.researcher", icon: Lightbulb },
+  { id: "creator", nameKey: "discovery:scenarios.filters.creator", icon: Video },
+  { id: "pm", nameKey: "discovery:scenarios.filters.pm", icon: Users },
+  { id: "business", nameKey: "discovery:scenarios.filters.businessFunc", icon: Briefcase },
 ];
 
 // Map career types to job functions
@@ -142,7 +142,7 @@ const careerJobFunctions: Record<string, string> = {
 
 export default function ScenariosPage() {
   const router = useRouter();
-  const { i18n } = useTranslation(["discovery", "skills"]);
+  const { t, i18n } = useTranslation(["discovery", "skills"]);
   const { isLoggedIn } = useAuth();
   useUserData(); // Trigger user data loading
   const [selectedIndustry, setSelectedIndustry] = useState("all");
@@ -393,10 +393,10 @@ export default function ScenariosPage() {
         {/* Header */}
         <div className="text-center mb-12">
           <h1 className="text-4xl font-bold text-gray-900 mb-4">
-            探索職業冒險
+            {t("discovery:scenarios.heading")}
           </h1>
           <p className="text-lg text-gray-600 max-w-3xl mx-auto">
-            選擇你的職業角色，開始獨特的學習冒險。每個職業都有精心設計的故事情境和挑戰任務。
+            {t("discovery:scenarios.subheading")}
           </p>
         </div>
 
@@ -416,7 +416,7 @@ export default function ScenariosPage() {
             >
               <div className="flex items-center space-x-2">
                 <Sparkles className="w-4 h-4" />
-                <span>全部</span>
+                <span>{t("discovery:scenarios.tabAll")}</span>
               </div>
             </button>
             {isLoggedIn && (
@@ -433,7 +433,7 @@ export default function ScenariosPage() {
               >
                 <div className="flex items-center space-x-2">
                   <Rocket className="w-4 h-4" />
-                  <span>我的冒險</span>
+                  <span>{t("discovery:scenarios.tabMy")}</span>
                 </div>
               </button>
             )}
@@ -445,9 +445,9 @@ export default function ScenariosPage() {
           <div className="flex flex-col items-center gap-3 mb-8">
             {/* Row 1: Industry */}
             <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-500 font-medium w-12 text-right shrink-0">產業</span>
+              <span className="text-sm text-gray-500 font-medium w-12 text-right shrink-0">{t("discovery:scenarios.labelIndustry")}</span>
               <div className="inline-flex flex-wrap justify-center rounded-lg border border-gray-200 bg-white p-1 gap-0.5">
-                {industryFilters.map((filter) => {
+                {industryFilterDefs.map((filter) => {
                   const Icon = filter.icon;
                   return (
                     <button
@@ -463,7 +463,7 @@ export default function ScenariosPage() {
                       `}
                     >
                       <Icon className="w-3.5 h-3.5" />
-                      <span>{filter.name}</span>
+                      <span>{t(filter.nameKey)}</span>
                     </button>
                   );
                 })}
@@ -471,9 +471,9 @@ export default function ScenariosPage() {
             </div>
             {/* Row 2: Job Function */}
             <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-500 font-medium w-12 text-right shrink-0">職能</span>
+              <span className="text-sm text-gray-500 font-medium w-12 text-right shrink-0">{t("discovery:scenarios.labelJobFunction")}</span>
               <div className="inline-flex flex-wrap justify-center rounded-lg border border-gray-200 bg-white p-1 gap-0.5">
-                {jobFunctionFilters.map((filter) => {
+                {jobFunctionFilterDefs.map((filter) => {
                   const Icon = filter.icon;
                   return (
                     <button
@@ -489,7 +489,7 @@ export default function ScenariosPage() {
                       `}
                     >
                       <Icon className="w-3.5 h-3.5" />
-                      <span>{filter.name}</span>
+                      <span>{t(filter.nameKey)}</span>
                     </button>
                   );
                 })}
@@ -504,7 +504,7 @@ export default function ScenariosPage() {
           <div className="text-center py-16">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600 mx-auto mb-4"></div>
             <p className="text-gray-500">
-              {activeTab === "my" ? "載入我的學習歷程..." : "載入職業冒險中..."}
+              {activeTab === "my" ? t("discovery:scenarios.loadingMy") : t("discovery:scenarios.loadingAll")}
             </p>
           </div>
         )}
@@ -533,19 +533,19 @@ export default function ScenariosPage() {
               {activeTab === "my" ? (
                 <div>
                   <Sparkles className="w-16 h-16 text-gray-300 mx-auto mb-4" />
-                  <p className="text-gray-500 mb-4">還沒有開始任何學習歷程</p>
+                  <p className="text-gray-500 mb-4">{t("discovery:scenarios.emptyMyTitle")}</p>
                   <p className="text-sm text-gray-400 mb-6">
-                    選擇一個職業路徑，開始你的探索之旅
+                    {t("discovery:scenarios.emptyMySubtitle")}
                   </p>
                   <button
                     onClick={() => setActiveTab("all")}
                     className="inline-flex items-center px-6 py-3 bg-purple-600 text-white rounded-lg font-medium hover:bg-purple-700 transition-colors"
                   >
-                    瀏覽所有職業
+                    {t("discovery:scenarios.browseAll")}
                   </button>
                 </div>
               ) : (
-                <p className="text-gray-500">沒有找到符合條件的職業冒險</p>
+                <p className="text-gray-500">{t("discovery:scenarios.emptyFiltered")}</p>
               )}
             </div>
           )}

--- a/frontend/src/lib/middleware/ai-token-tracker.ts
+++ b/frontend/src/lib/middleware/ai-token-tracker.ts
@@ -1,0 +1,216 @@
+/**
+ * Per-User AI Token Budget Tracker
+ *
+ * Tracks each user's daily AI token usage stored in users.metadata JSON column.
+ * Structure: { aiUsage: { date: "YYYY-MM-DD", tokensUsed: number, sessionsStarted: number } }
+ *
+ * Resets daily based on date comparison.
+ */
+
+import { getPool } from "@/lib/db/get-pool";
+
+// Daily limits
+export const DAILY_TOKEN_LIMIT = 200_000;
+export const DAILY_SESSION_LIMIT = 5;
+
+export interface UserAiUsage {
+  date: string;
+  tokensUsed: number;
+  sessionsStarted: number;
+}
+
+export interface BudgetStatus {
+  tokensUsed: number;
+  tokensLimit: number;
+  tokensRemaining: number;
+  sessionsStarted: number;
+  sessionsLimit: number;
+  sessionsRemaining: number;
+  resetAt: string;
+  hasTokenBudget: boolean;
+  hasSessionBudget: boolean;
+}
+
+/**
+ * Get today's date string in YYYY-MM-DD format (UTC)
+ */
+function getTodayDate(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+/**
+ * Get reset time for next UTC midnight as ISO string
+ */
+function getResetAtTime(): string {
+  const now = new Date();
+  const tomorrow = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1)
+  );
+  return tomorrow.toISOString();
+}
+
+/**
+ * Fetch the current aiUsage from users.metadata for a given user.
+ * Returns a fresh/reset record if the stored date differs from today.
+ */
+export async function getUserAiUsage(userId: string): Promise<UserAiUsage> {
+  const pool = getPool();
+  const today = getTodayDate();
+
+  const { rows } = await pool.query(
+    `SELECT metadata FROM users WHERE id = $1`,
+    [userId]
+  );
+
+  if (rows.length === 0) {
+    return { date: today, tokensUsed: 0, sessionsStarted: 0 };
+  }
+
+  const metadata = (rows[0].metadata as Record<string, unknown>) || {};
+  const stored = metadata.aiUsage as UserAiUsage | undefined;
+
+  // Reset if a new day
+  if (!stored || stored.date !== today) {
+    return { date: today, tokensUsed: 0, sessionsStarted: 0 };
+  }
+
+  return stored;
+}
+
+/**
+ * Get budget status for a user.
+ */
+export async function getBudgetStatus(userId: string): Promise<BudgetStatus> {
+  const usage = await getUserAiUsage(userId);
+  const tokensRemaining = Math.max(0, DAILY_TOKEN_LIMIT - usage.tokensUsed);
+  const sessionsRemaining = Math.max(
+    0,
+    DAILY_SESSION_LIMIT - usage.sessionsStarted
+  );
+
+  return {
+    tokensUsed: usage.tokensUsed,
+    tokensLimit: DAILY_TOKEN_LIMIT,
+    tokensRemaining,
+    sessionsStarted: usage.sessionsStarted,
+    sessionsLimit: DAILY_SESSION_LIMIT,
+    sessionsRemaining,
+    resetAt: getResetAtTime(),
+    hasTokenBudget: tokensRemaining > 0,
+    hasSessionBudget: sessionsRemaining > 0,
+  };
+}
+
+/**
+ * Increment token usage for a user after an AI call.
+ * Uses a simple read-modify-write with optimistic concurrency (no row lock needed
+ * for approximate tracking).
+ */
+export async function recordTokenUsage(
+  userId: string,
+  tokensUsed: number
+): Promise<void> {
+  if (tokensUsed <= 0) return;
+
+  const pool = getPool();
+  const today = getTodayDate();
+
+  // Atomic update using jsonb merge — reset if date changed
+  await pool.query(
+    `UPDATE users
+     SET metadata = jsonb_set(
+       COALESCE(metadata, '{}'::jsonb),
+       '{aiUsage}',
+       CASE
+         WHEN (metadata->'aiUsage'->>'date') = $2
+         THEN jsonb_build_object(
+           'date', $2::text,
+           'tokensUsed', COALESCE((metadata->'aiUsage'->>'tokensUsed')::int, 0) + $3,
+           'sessionsStarted', COALESCE((metadata->'aiUsage'->>'sessionsStarted')::int, 0)
+         )
+         ELSE jsonb_build_object(
+           'date', $2::text,
+           'tokensUsed', $3::int,
+           'sessionsStarted', 0
+         )
+       END
+     ),
+     updated_at = NOW()
+     WHERE id = $1`,
+    [userId, today, tokensUsed]
+  );
+}
+
+/**
+ * Increment session count for a user when a new Discovery program is started.
+ * Returns false if the daily session limit has been exceeded.
+ */
+export async function checkAndIncrementSession(
+  userId: string
+): Promise<{ allowed: boolean; sessionsRemaining: number }> {
+  const pool = getPool();
+  const today = getTodayDate();
+
+  // Use a transaction to avoid race conditions
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const { rows } = await client.query(
+      `SELECT metadata FROM users WHERE id = $1 FOR UPDATE`,
+      [userId]
+    );
+
+    if (rows.length === 0) {
+      await client.query("ROLLBACK");
+      return { allowed: true, sessionsRemaining: DAILY_SESSION_LIMIT - 1 };
+    }
+
+    const metadata = (rows[0].metadata as Record<string, unknown>) || {};
+    const stored = metadata.aiUsage as UserAiUsage | undefined;
+
+    let current: UserAiUsage;
+    if (!stored || stored.date !== today) {
+      current = { date: today, tokensUsed: 0, sessionsStarted: 0 };
+    } else {
+      current = stored;
+    }
+
+    if (current.sessionsStarted >= DAILY_SESSION_LIMIT) {
+      await client.query("ROLLBACK");
+      return { allowed: false, sessionsRemaining: 0 };
+    }
+
+    const updated: UserAiUsage = {
+      ...current,
+      sessionsStarted: current.sessionsStarted + 1,
+    };
+
+    await client.query(
+      `UPDATE users
+       SET metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{aiUsage}', $2::jsonb),
+           updated_at = NOW()
+       WHERE id = $1`,
+      [userId, JSON.stringify(updated)]
+    );
+
+    await client.query("COMMIT");
+    return {
+      allowed: true,
+      sessionsRemaining: DAILY_SESSION_LIMIT - updated.sessionsStarted,
+    };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Check if user has remaining token budget without modifying anything.
+ */
+export async function hasTokenBudget(userId: string): Promise<boolean> {
+  const usage = await getUserAiUsage(userId);
+  return usage.tokensUsed < DAILY_TOKEN_LIMIT;
+}

--- a/frontend/src/lib/services/discovery-learning-service.ts
+++ b/frontend/src/lib/services/discovery-learning-service.ts
@@ -21,6 +21,7 @@ import type {
   TaskResult,
   CompletionResult,
 } from "./base-learning-service";
+import { DiscoveryYAMLLoader } from "./discovery-yaml-loader";
 
 export interface DiscoveryScenarioData {
   pathId: string;


### PR DESCRIPTION
## Summary
- Unify token tracking: PBL + Discovery both write to DB (was in-memory for PBL)
- Add budget check to next-task route (was bypassing daily AI token limit)
- Fix Prisma skills default from `[]` to `{}` matching runtime type
- Add banner image to scenario detail page (was gradient-only)
- Fix missing `?lang=` parameter on scenario detail API call
- Extract 57+ hardcoded Chinese strings to i18n across 6 Discovery pages
- Fix program creation to use `/start` endpoint (AI-generated tasks from YAML)
- Update tests for i18n key changes (22/22 pass)

## Verified
- CI: Run #23979897771 ✅
- Preview: `ai-square-preview-issue-106` live, HTTP 200
- API: `/api/discovery/scenarios?lang=zhTW` returns 中文 titles
- API: scenario detail returns 中文 with `?lang=zhTW`
- Banner: `robotics_engineer.webp` HTTP 200

## Test plan
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Unit tests pass (22/22 in affected file)
- [x] Build passes
- [x] Preview deploy successful
- [ ] Manual test: login to Discovery, verify banner + i18n on scenario detail
- [ ] Manual test: start a program, verify tasks have context (not generic "Career Exploration")

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)