### PR TITLE
fix(discovery): add banner to program detail page

### DIFF
--- a/frontend/src/app/discovery/scenarios/[id]/programs/[programId]/page.tsx
+++ b/frontend/src/app/discovery/scenarios/[id]/programs/[programId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import Image from "next/image";
 import {
   Sparkles,
   CheckCircle,
@@ -250,31 +251,40 @@ export default function ProgramDetailPage({
           <span>{t("program.backToScenario")}</span>
         </button>
 
-        {/* Career Info Card */}
-        <div className="bg-gradient-to-br from-purple-50 to-blue-50 rounded-2xl p-6 mb-6 border border-purple-100">
-          <div className="flex items-start space-x-4">
-            <div
-              className={`w-16 h-16 bg-gradient-to-br ${currentCareer.color} rounded-xl flex items-center justify-center flex-shrink-0`}
-            >
-              <CareerIcon className="w-8 h-8 text-white" />
+        {/* Career Info Card with Banner */}
+        <div className="bg-white rounded-2xl shadow-md overflow-hidden mb-6">
+          <div className={`h-32 bg-gradient-to-br ${currentCareer.color} relative overflow-hidden`}>
+            <Image
+              src={`/images/discovery-banners/${programData.careerType || "general"}.webp`}
+              alt={currentCareer.title}
+              fill
+              className="object-cover"
+              sizes="(max-width: 768px) 100vw, 800px"
+              onError={(e) => {
+                (e.target as HTMLImageElement).style.display = "none";
+              }}
+            />
+            <div className="absolute inset-0 bg-black/10" />
+            <div className="absolute inset-0 flex items-center justify-center">
+              <CareerIcon className="w-12 h-12 text-white/90" />
             </div>
-            <div className="flex-1">
-              <h2 className="text-xl font-bold text-gray-900 mb-2">
-                {currentCareer.title}
-              </h2>
-              {currentCareer.skills.length > 0 && (
-                <div className="flex flex-wrap gap-2">
-                  {currentCareer.skills.map((skill, i) => (
-                    <span
-                      key={i}
-                      className="px-2 py-1 bg-white/70 text-gray-700 text-xs rounded-md"
-                    >
-                      {skill}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </div>
+          </div>
+          <div className="p-4">
+            <h2 className="text-xl font-bold text-gray-900 mb-2">
+              {currentCareer.title}
+            </h2>
+            {currentCareer.skills.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {currentCareer.skills.map((skill, i) => (
+                  <span
+                    key={i}
+                    className="px-2 py-1 bg-purple-50 text-purple-700 text-xs rounded-md"
+                  >
+                    {skill}
+                  </span>
+                ))}
+              </div>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Add banner image to program detail page career info card, replacing the small icon-only box.

Now matches the scenario detail page style with full-width banner.

## Test plan
- [x] TypeScript passes
- [x] ESLint passes  
- [ ] Visual: program detail page shows career banner image

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)